### PR TITLE
feat: support getter-backed rule filters

### DIFF
--- a/docs/source/how-tos/create-rule-filters.md
+++ b/docs/source/how-tos/create-rule-filters.md
@@ -4,7 +4,9 @@ Rule filters declare predicate logic that restricts which source or target compo
 
 ## Leaf filters
 
-A leaf filter must set `field`, `op`, and either `values` or `prefixes`. The `values` list works for equality, inequality, membership, and numeric comparisons:
+A leaf filter must set either `field` or `getter`, plus `op`, and either `values` or `prefixes`. Use `field` when the candidate value lives directly on the source component. Use `getter` when the candidate must be computed from the source component and `PluginContext`. Getter values are typically registered `@getter` names, and the loader also accepts dotted attribute paths for simple lookups.
+
+Field-backed example:
 
 ```json
 {
@@ -13,6 +15,18 @@ A leaf filter must set `field`, `op`, and either `values` or `prefixes`. The `va
   "values": ["gas"]
 }
 ```
+
+Getter-backed example:
+
+```json
+{
+  "getter": "selected_fuel_type",
+  "op": "eq",
+  "values": ["gas"]
+}
+```
+
+When evaluating getter-backed filters, the executor passes the current `PluginContext` into the getter so the candidate value can depend on translator state.
 
 Case-insensitive matching is the default; the `casefold` flag controls whether string inputs are normalized.
 

--- a/docs/source/how-tos/create-rule-filters.md
+++ b/docs/source/how-tos/create-rule-filters.md
@@ -26,7 +26,34 @@ Getter-backed example:
 }
 ```
 
-When evaluating getter-backed filters, the executor passes the current `PluginContext` into the getter so the candidate value can depend on translator state.
+When evaluating getter-backed filters, the executor passes the current `PluginContext` into the getter so the candidate value can depend on translator state. Use this shape when the choice depends on translator metadata, supplemental attributes, or other source-system lookups that are not present as a direct source field.
+
+### Loading getter-backed filters from records
+
+If you load rules from JSON or another record format, store the getter name in the filter record and make sure the matching `@getter` has been registered before loading:
+
+```python
+>>> from r2x_core import Rule
+>>> from r2x_core.getters import getter
+>>>
+>>> @getter
+... def selected_fuel_type(source, *, context):
+...     return context.metadata["selected_fuel_type"]
+>>>
+>>> rules = Rule.from_records([
+...     {
+...         "source_type": "PlantComponent",
+...         "target_type": "StationComponent",
+...         "version": 1,
+...         "field_map": {"name": "name"},
+...         "filter": {
+...             "getter": "selected_fuel_type",
+...             "op": "eq",
+...             "values": ["gas"],
+...         },
+...     }
+... ])
+```
 
 Case-insensitive matching is the default; the `casefold` flag controls whether string inputs are normalized.
 

--- a/docs/source/how-tos/define-rule-mappings.md
+++ b/docs/source/how-tos/define-rule-mappings.md
@@ -68,6 +68,19 @@ The {py:class}`~r2x_core.RuleFilter` class restricts which components a rule pro
 
 Use a field-backed filter when the selection value is already present on the source component. Use a getter-backed filter when the candidate value must be derived from translator context, supplemental attributes, or other source-system lookups. If a filter uses `getter`, call `matches(component, context=...)` with the active `PluginContext`, because the getter-backed path needs that context to evaluate.
 
+```python doctest
+>>> from types import SimpleNamespace
+>>> from rust_ok import Ok
+>>> from r2x_core import RuleFilter
+>>> from r2x_core.plugin_config import PluginConfig
+>>> from r2x_core.plugin_context import PluginContext
+>>>
+>>> ctx = PluginContext(config=PluginConfig(models=[]), metadata={"selected_fuel_type": "gas"})
+>>> filt = RuleFilter(getter=lambda _src, *, context: Ok(context.metadata["selected_fuel_type"]), op="eq", values=["gas"])
+>>> filt.matches(SimpleNamespace(), context=ctx)
+True
+```
+
 Filters are evaluated before translation begins, so components that don't match are skipped entirely. This improves performance when only a subset of components needs translation.
 
 ## RuleFilter Operations

--- a/docs/source/how-tos/define-rule-mappings.md
+++ b/docs/source/how-tos/define-rule-mappings.md
@@ -66,6 +66,8 @@ The {py:class}`~r2x_core.RuleFilter` class restricts which components a rule pro
 'eq'
 ```
 
+Use a field-backed filter when the selection value is already present on the source component. Use a getter-backed filter when the candidate value must be derived from translator context, supplemental attributes, or other source-system lookups. If a filter uses `getter`, call `matches(component, context=...)` with the active `PluginContext`, because the getter-backed path needs that context to evaluate.
+
 Filters are evaluated before translation begins, so components that don't match are skipped entirely. This improves performance when only a subset of components needs translation.
 
 ## RuleFilter Operations

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -185,3 +185,38 @@ True
 ```{eval-rst}
 .. autofunction:: r2x_core.utils.run_upgrade_step
 ```
+
+## Results
+
+```{eval-rst}
+.. autoclass:: r2x_core.Result
+   :members:
+   :show-inheritance:
+   :no-index:
+```
+
+```{eval-rst}
+.. autoclass:: r2x_core.Ok
+   :members:
+   :show-inheritance:
+   :no-index:
+```
+
+```{eval-rst}
+.. autoclass:: r2x_core.Err
+   :members:
+   :show-inheritance:
+   :no-index:
+```
+
+```{eval-rst}
+.. autofunction:: r2x_core.is_ok
+```
+
+```{eval-rst}
+.. autofunction:: r2x_core.is_err
+```
+
+## Data Processors
+
+See {doc}`./processors` for complete processor documentation.

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -249,6 +249,19 @@ Complete API documentation for all r2x-core classes and functions.
 .. autofunction:: r2x_core.getter
 ```
 
+```python doctest
+>>> from r2x_core import getter, resolve_getter
+>>>
+>>> @getter(name="api_resolve_getter")
+... def api_resolve_getter(component, *, context):
+...     _ = component
+...     _ = context
+...     return "resolved"
+>>>
+>>> resolve_getter("api_resolve_getter") is api_resolve_getter
+True
+```
+
 ```{eval-rst}
 .. autofunction:: r2x_core.resolve_getter
 ```

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -118,132 +118,14 @@ Complete API documentation for all r2x-core classes and functions.
 ```{eval-rst}
 .. autoclass:: r2x_core.Rule
    :members:
-   :show-inheritance:
 ```
 
 ```{eval-rst}
 .. autoclass:: r2x_core.RuleFilter
    :members:
-   :show-inheritance:
 ```
 
-```{eval-rst}
-.. autoclass:: r2x_core.RuleResult
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.TranslationResult
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autofunction:: r2x_core.apply_rules_to_context
-```
-
-```{eval-rst}
-.. autofunction:: r2x_core.apply_single_rule
-```
-
-## Exceptions
-
-```{eval-rst}
-.. autoclass:: r2x_core.ValidationError
-   :members:
-   :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.ComponentCreationError
-   :members:
-   :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.CLIError
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.PluginError
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.UpgradeError
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-## Versioning and Upgrades
-
-```{eval-rst}
-.. autoclass:: r2x_core.SemanticVersioningStrategy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.GitVersioningStrategy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.VersionReader
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.VersionStrategy
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.UpgradeStep
-   :members:
-   :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: r2x_core.UpgradeType
-   :members:
-   :show-inheritance:
-   :no-index:
-```
-
-```{eval-rst}
-.. autofunction:: r2x_core.run_upgrade_step
-```
-
-## Utilities
-
-```{eval-rst}
-.. autofunction:: r2x_core.components_to_records
-```
-
-```{eval-rst}
-.. autofunction:: r2x_core.export_components_to_csv
-```
-
-```{eval-rst}
-.. autofunction:: r2x_core.create_component
-```
+## Getters
 
 ```{eval-rst}
 .. autofunction:: r2x_core.getter
@@ -258,7 +140,10 @@ Complete API documentation for all r2x-core classes and functions.
 ...     _ = context
 ...     return "resolved"
 >>>
->>> resolve_getter("api_resolve_getter") is api_resolve_getter
+>>> resolved = resolve_getter("api_resolve_getter")
+>>> resolved.is_ok()
+True
+>>> resolved.unwrap() is api_resolve_getter
 True
 ```
 
@@ -285,37 +170,18 @@ True
 .. autofunction:: r2x_core.utils.validate_file_extension
 ```
 
-## Results
-
 ```{eval-rst}
-.. autoclass:: r2x_core.Result
-   :members:
-   :show-inheritance:
-   :no-index:
+.. autofunction:: r2x_core.utils.export_components_to_csv
 ```
 
 ```{eval-rst}
-.. autoclass:: r2x_core.Ok
-   :members:
-   :show-inheritance:
-   :no-index:
+.. autofunction:: r2x_core.utils.components_to_records
 ```
 
 ```{eval-rst}
-.. autoclass:: r2x_core.Err
-   :members:
-   :show-inheritance:
-   :no-index:
+.. autofunction:: r2x_core.utils.create_component
 ```
 
 ```{eval-rst}
-.. autofunction:: r2x_core.is_ok
+.. autofunction:: r2x_core.utils.run_upgrade_step
 ```
-
-```{eval-rst}
-.. autofunction:: r2x_core.is_err
-```
-
-## Data Processors
-
-See {doc}`./processors` for complete processor documentation.

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -250,6 +250,10 @@ Complete API documentation for all r2x-core classes and functions.
 ```
 
 ```{eval-rst}
+.. autofunction:: r2x_core.resolve_getter
+```
+
+```{eval-rst}
 .. autofunction:: r2x_core.transfer_time_series_metadata
 ```
 

--- a/src/r2x_core/__init__.py
+++ b/src/r2x_core/__init__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         ValidationError,
     )
     from .file_types import FileFormat, H5Format
-    from .getters import getter
+    from .getters import getter, resolve_getter
     from .plugin_base import Plugin
     from .plugin_config import PluginConfig
     from .plugin_context import PluginContext
@@ -76,6 +76,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "FileFormat": ".file_types",
     "H5Format": ".file_types",
     "getter": ".getters",
+    "resolve_getter": ".getters",
     "Plugin": ".plugin_base",
     "PluginConfig": ".plugin_config",
     "PluginContext": ".plugin_context",
@@ -174,6 +175,7 @@ __all__ = [
     "h5_readers",
     "is_err",
     "is_ok",
+    "resolve_getter",
     "run_upgrade_step",
     "set_unit_system",
     "transfer_time_series_metadata",

--- a/src/r2x_core/getters.py
+++ b/src/r2x_core/getters.py
@@ -52,26 +52,36 @@ def getter(func: F | None = None, *, name: str | None = None) -> F | Callable[[F
     return _decorator
 
 
-def _preprocess_rule_getters(getters_dict: dict[str, Any]) -> Result[dict[str, Any], TypeError]:
-    """Convert string-based getters in a rule into callables."""
+def resolve_getter(getter: GetterFunc | str) -> Result[GetterFunc, TypeError]:
+    """Resolve a getter reference to a callable."""
     from .utils import build_attr_getter
 
+    if callable(getter):
+        return Ok(getter)
+    if getter in GETTER_REGISTRY:
+        return Ok(GETTER_REGISTRY[getter])
+    if "." not in getter:
+        logger.warning(
+            "Getter '{}' not found in registry; ensure it is imported before loading rules. Falling back to attribute lookup.",
+            getter,
+        )
+    return Ok(build_attr_getter(getter.split(".")))
+
+
+def _preprocess_rule_getters(getters_dict: dict[str, Any]) -> Result[dict[str, Any], TypeError]:
+    """Convert string-based getters in a rule into callables."""
     resolved: dict[str, GetterFunc] = {}
     for field, getter in getters_dict.items():
         if callable(getter):
             resolved[field] = getter
         elif isinstance(getter, str):
-            if getter in GETTER_REGISTRY:
-                resolved[field] = GETTER_REGISTRY[getter]
-            else:
-                if "." not in getter:
-                    logger.warning(
-                        "Getter '{}' for field '{}' not found in registry; ensure it is imported before loading rules. "
-                        "Falling back to attribute lookup.",
-                        getter,
-                        field,
-                    )
-                resolved[field] = build_attr_getter(getter.split("."))
+            result = resolve_getter(getter)
+            if result.is_err():
+                return Err(result.err())
+            resolved_getter = result.ok()
+            if resolved_getter is None:
+                return Err(TypeError(f"Getter resolution returned no callable for '{field}'"))
+            resolved[field] = resolved_getter
         else:
             return Err(TypeError(f"Invalid getter type for '{field}': {type(getter).__name__}"))
     return Ok(resolved)

--- a/src/r2x_core/getters.py
+++ b/src/r2x_core/getters.py
@@ -75,13 +75,7 @@ def _preprocess_rule_getters(getters_dict: dict[str, Any]) -> Result[dict[str, A
         if callable(getter):
             resolved[field] = getter
         elif isinstance(getter, str):
-            result = resolve_getter(getter)
-            if result.is_err():
-                return Err(result.err())
-            resolved_getter = result.ok()
-            if resolved_getter is None:
-                return Err(TypeError(f"Getter resolution returned no callable for '{field}'"))
-            resolved[field] = resolved_getter
+            resolved[field] = resolve_getter(getter).unwrap_or_raise()
         else:
             return Err(TypeError(f"Invalid getter type for '{field}': {type(getter).__name__}"))
     return Ok(resolved)

--- a/src/r2x_core/rules.py
+++ b/src/r2x_core/rules.py
@@ -6,8 +6,10 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias
 
-from pydantic import BaseModel, PrivateAttr, model_validator
+from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 from rust_ok import Result
+
+from .plugin_context import PluginContext
 
 if TYPE_CHECKING:
     pass
@@ -17,7 +19,7 @@ class RuleFilter(BaseModel):
     """Declarative predicate for selecting source components."""
 
     field: str | None = None
-    getter: RuleGetter | str | None = None
+    getter: RuleGetter | None = None
     op: Literal["eq", "neq", "in", "not_in", "geq", "startswith", "not_startswith", "endswith"] | None = None
     values: list[Any] | None = None
     prefixes: list[str] | None = None
@@ -26,6 +28,25 @@ class RuleFilter(BaseModel):
     casefold: bool = True
     on_missing: Literal["include", "exclude"] = "exclude"
     _normalized_values: list[Any] | None = PrivateAttr(None)
+
+    @field_validator("getter", mode="before")
+    @classmethod
+    def _validate_getter(cls, value: Any) -> Any:
+        """Resolve string getter references into callables."""
+        if value is None or callable(value):
+            return value
+        if not isinstance(value, str):
+            raise TypeError(f"RuleFilter.getter must be callable or str, not {type(value).__name__}")
+
+        from .getters import resolve_getter
+
+        resolved = resolve_getter(value)
+        if resolved.is_err():
+            raise ValueError(str(resolved.err()))
+        getter = resolved.ok()
+        if getter is None:
+            raise ValueError("RuleFilter getter resolution returned no callable")
+        return getter
 
     @model_validator(mode="after")
     def _validate_structure(self) -> RuleFilter:
@@ -67,12 +88,6 @@ class RuleFilter(BaseModel):
                     raise ValueError("RuleFilter.prefixes entries must be strings")
                 object.__setattr__(self, "values", prefix_values)
 
-            if isinstance(self.getter, str):
-                from .getters import _preprocess_rule_getters
-
-                resolved = _preprocess_rule_getters({"getter": self.getter}).unwrap_or_raise()
-                object.__setattr__(self, "getter", resolved["getter"])
-
             # Precompute casefolded values once so evaluate_rule_filter does not
             # recompute them per component.
             normalized = [
@@ -83,7 +98,7 @@ class RuleFilter(BaseModel):
 
         return self
 
-    def matches(self, component: Any, *, context: Any | None = None) -> bool:
+    def matches(self, component: Any, *, context: PluginContext | None = None) -> bool:
         """Evaluate this filter against a component instance."""
         from .utils import evaluate_rule_filter
 

--- a/src/r2x_core/rules.py
+++ b/src/r2x_core/rules.py
@@ -40,12 +40,7 @@ class RuleFilter(BaseModel):
 
         from .getters import resolve_getter
 
-        resolved = resolve_getter(value)
-        if resolved.is_err():
-            raise ValueError(str(resolved.err()))
-        getter = resolved.ok()
-        if getter is None:
-            raise ValueError("RuleFilter getter resolution returned no callable")
+        getter = resolve_getter(value).unwrap_or_raise()
         return getter
 
     @model_validator(mode="after")
@@ -79,8 +74,8 @@ class RuleFilter(BaseModel):
             if self.op == "geq" and len(self.values or []) != 1:
                 raise ValueError("RuleFilter.geq expects exactly one comparison value")
             if self.op in {"startswith", "not_startswith"}:
-                prefix_values = self.prefixes if self.prefixes else self.values
-                if not prefix_values:
+                prefix_values = self.prefixes if self.prefixes is not None else self.values
+                if prefix_values is None:
                     raise ValueError(
                         "RuleFilter.prefixes must provide at least one entry for prefix operations"
                     )

--- a/src/r2x_core/rules.py
+++ b/src/r2x_core/rules.py
@@ -17,6 +17,7 @@ class RuleFilter(BaseModel):
     """Declarative predicate for selecting source components."""
 
     field: str | None = None
+    getter: RuleGetter | str | None = None
     op: Literal["eq", "neq", "in", "not_in", "geq", "startswith", "not_startswith", "endswith"] | None = None
     values: list[Any] | None = None
     prefixes: list[str] | None = None
@@ -31,6 +32,7 @@ class RuleFilter(BaseModel):
         """Ensure the filter is either a leaf or a composition."""
         is_leaf = (
             self.field is not None
+            or self.getter is not None
             or self.op is not None
             or self.values is not None
             or self.prefixes is not None
@@ -45,7 +47,9 @@ class RuleFilter(BaseModel):
             raise ValueError("RuleFilter cannot set both any_of and all_of")
 
         if is_leaf:
-            if not self.field:
+            if self.field and self.getter:
+                raise ValueError("RuleFilter cannot set both field and getter")
+            if not self.field and self.getter is None:
                 raise ValueError("RuleFilter.field is required for leaf filters")
             if self.op is None:
                 raise ValueError("RuleFilter.op is required for leaf filters")
@@ -63,6 +67,12 @@ class RuleFilter(BaseModel):
                     raise ValueError("RuleFilter.prefixes entries must be strings")
                 object.__setattr__(self, "values", prefix_values)
 
+            if isinstance(self.getter, str):
+                from .getters import _preprocess_rule_getters
+
+                resolved = _preprocess_rule_getters({"getter": self.getter}).unwrap_or_raise()
+                object.__setattr__(self, "getter", resolved["getter"])
+
             # Precompute casefolded values once so evaluate_rule_filter does not
             # recompute them per component.
             normalized = [
@@ -73,11 +83,11 @@ class RuleFilter(BaseModel):
 
         return self
 
-    def matches(self, component: Any) -> bool:
+    def matches(self, component: Any, *, context: Any | None = None) -> bool:
         """Evaluate this filter against a component instance."""
         from .utils import evaluate_rule_filter
 
-        return evaluate_rule_filter(component, rule_filter=self)
+        return evaluate_rule_filter(component, rule_filter=self, context=context)
 
 
 RuleGetter: TypeAlias = Callable[..., Result[Any, ValueError]]

--- a/src/r2x_core/rules.py
+++ b/src/r2x_core/rules.py
@@ -19,7 +19,7 @@ class RuleFilter(BaseModel):
     """Declarative predicate for selecting source components."""
 
     field: str | None = None
-    getter: RuleGetter | None = None
+    getter: RuleGetter | str | None = None
     op: Literal["eq", "neq", "in", "not_in", "geq", "startswith", "not_startswith", "endswith"] | None = None
     values: list[Any] | None = None
     prefixes: list[str] | None = None

--- a/src/r2x_core/rules_executor.py
+++ b/src/r2x_core/rules_executor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any, cast
 from uuid import uuid4
 
@@ -122,14 +121,15 @@ def apply_single_rule(rule: Rule, *, context: PluginContext) -> Result[RuleAppli
         assert resolved_class is not None
         resolved_targets.append(resolved_class)
 
-    filter_func: Callable[[Any], bool] | None = None
-    if rule.filter is not None:
-        rule_filter = rule.filter
-        filter_func = lambda comp, rf=rule_filter: evaluate_rule_filter(comp, rule_filter=rf)  # noqa: E731
-
     found_component = False
 
-    for src_component in iter_components(read_system, class_type=source_class, filter_func=filter_func):
+    for src_component in iter_components(read_system, class_type=source_class):
+        if rule.filter is not None:
+            try:
+                if not evaluate_rule_filter(src_component, rule_filter=rule.filter, context=context):
+                    continue
+            except ValueError as exc:
+                return Err(ValueError(f"Failed to evaluate filter for {src_component.label}: {exc}"))
         found_component = True
         for target_class in resolved_targets:
             fields_result = build_target_fields(src_component, rule=rule, context=context).map_err(

--- a/src/r2x_core/utils/rules.py
+++ b/src/r2x_core/utils/rules.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import importlib
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from rust_ok import Err, Ok, Result
 
@@ -144,21 +144,50 @@ def build_component_kwargs(
     return Ok(kwargs)
 
 
-def evaluate_rule_filter(component: Any, *, rule_filter: RuleFilter) -> bool:
+def evaluate_rule_filter(
+    component: Any, *, rule_filter: RuleFilter, context: PluginContext | None = None
+) -> bool:
     """Return True if the component satisfies the rule filter."""
     if rule_filter.any_of is not None:
-        return any(evaluate_rule_filter(component, rule_filter=child) for child in rule_filter.any_of)
+        return any(
+            evaluate_rule_filter(component, rule_filter=child, context=context)
+            for child in rule_filter.any_of
+        )
     if rule_filter.all_of is not None:
-        return all(evaluate_rule_filter(component, rule_filter=child) for child in rule_filter.all_of)
+        return all(
+            evaluate_rule_filter(component, rule_filter=child, context=context)
+            for child in rule_filter.all_of
+        )
 
-    if rule_filter.field is None or rule_filter.op is None or rule_filter.values is None:
+    if rule_filter.op is None or rule_filter.values is None:
         raise ValueError("RuleFilter must have field, op, and values for leaf filters")
 
-    attr = getattr(component, rule_filter.field, None)
-    if attr is None:
-        return rule_filter.on_missing == "include"
+    candidate: Any
+    if rule_filter.getter is not None:
+        if context is None:
+            raise ValueError("RuleFilter getter-backed filters require PluginContext")
+        getter_func = cast(Callable[..., Result[Any, ValueError]], rule_filter.getter)
+        result = getter_func(component, context=context)
+        match result:
+            case Ok(value):
+                candidate = value
+            case Err(e):
+                raise ValueError(f"Getter for RuleFilter failed: {e}")
+            case _:
+                candidate = result
+        if candidate is None:
+            return rule_filter.on_missing == "include"
+    else:
+        if rule_filter.field is None:
+            raise ValueError("RuleFilter must have field or getter for leaf filters")
+        attr = getattr(component, rule_filter.field, None)
+        if attr is None:
+            return rule_filter.on_missing == "include"
+        candidate = attr
 
-    candidate = str(attr).casefold() if rule_filter.casefold and isinstance(attr, str) else attr
+    candidate = (
+        str(candidate).casefold() if rule_filter.casefold and isinstance(candidate, str) else candidate
+    )
     values = rule_filter._normalized_values
     assert values is not None, "_normalized_values must be set during RuleFilter construction"
     if values is None:
@@ -177,7 +206,7 @@ def evaluate_rule_filter(component: Any, *, rule_filter: RuleFilter) -> bool:
         return candidate not in values
     if rule_filter.op == "geq":
         try:
-            cand_num = float(candidate)
+            cand_num = float(cast(Any, candidate))
             threshold = float(values[0])
         except (TypeError, ValueError):
             return False

--- a/src/r2x_core/utils/rules.py
+++ b/src/r2x_core/utils/rules.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import importlib
 from collections import deque
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from rust_ok import Err, Ok, Result
 
@@ -166,15 +166,12 @@ def evaluate_rule_filter(
     if rule_filter.getter is not None:
         if context is None:
             raise ValueError("RuleFilter getter-backed filters require PluginContext")
-        getter_func = cast(Callable[..., Result[Any, ValueError]], rule_filter.getter)
-        result = getter_func(component, context=context)
+        result = rule_filter.getter(component, context=context)
         match result:
             case Ok(value):
                 candidate = value
             case Err(e):
                 raise ValueError(f"Getter for RuleFilter failed: {e}")
-            case _:
-                candidate = result
         if candidate is None:
             return rule_filter.on_missing == "include"
     else:
@@ -206,7 +203,7 @@ def evaluate_rule_filter(
         return candidate not in values
     if rule_filter.op == "geq":
         try:
-            cand_num = float(cast(Any, candidate))
+            cand_num = float(candidate)
             threshold = float(values[0])
         except (TypeError, ValueError):
             return False

--- a/src/r2x_core/utils/rules.py
+++ b/src/r2x_core/utils/rules.py
@@ -166,7 +166,10 @@ def evaluate_rule_filter(
     if rule_filter.getter is not None:
         if context is None:
             raise ValueError("RuleFilter getter-backed filters require PluginContext")
-        result = rule_filter.getter(component, context=context)
+        getter_func = rule_filter.getter
+        if not callable(getter_func):
+            raise ValueError("RuleFilter getter must resolve to a callable")
+        result = getter_func(component, context=context)
         match result:
             case Ok(value):
                 candidate = value

--- a/src/r2x_core/utils/rules.py
+++ b/src/r2x_core/utils/rules.py
@@ -190,11 +190,6 @@ def evaluate_rule_filter(
     )
     values = rule_filter._normalized_values
     assert values is not None, "_normalized_values must be set during RuleFilter construction"
-    if values is None:
-        values = [
-            str(val).casefold() if rule_filter.casefold and isinstance(val, str) else val
-            for val in rule_filter.values
-        ]
 
     if rule_filter.op == "eq":
         return candidate == values[0]

--- a/tests/test_getter.py
+++ b/tests/test_getter.py
@@ -270,3 +270,25 @@ def test_preprocess_rule_getters_rejects_invalid_types():
     result = _preprocess_rule_getters({"field": 123})
     assert result.is_err()
     assert isinstance(result.err(), TypeError)
+
+
+def test_resolve_getter_public_api_registers_and_resolves():
+    """The public getter resolver should resolve registry names."""
+    from rust_ok import Ok
+
+    from r2x_core import getter, resolve_getter
+    from r2x_core.getters import GETTER_REGISTRY
+
+    getter_name = "public_api_resolve_getter"
+    if getter_name not in GETTER_REGISTRY:
+
+        @getter(name=getter_name)
+        def public_api_resolve_getter(comp, *, context):
+            _ = comp
+            _ = context
+            return Ok("resolved")
+
+    result = resolve_getter(getter_name)
+    assert result.is_ok()
+    resolved = result.unwrap()
+    assert resolved is GETTER_REGISTRY[getter_name]

--- a/tests/test_getter.py
+++ b/tests/test_getter.py
@@ -292,3 +292,17 @@ def test_resolve_getter_public_api_registers_and_resolves():
     assert result.is_ok()
     resolved = result.unwrap()
     assert resolved is GETTER_REGISTRY[getter_name]
+
+
+def test_resolve_getter_callable_passthrough():
+    """resolve_getter returns callable inputs unchanged."""
+    from r2x_core import resolve_getter
+
+    def passthrough_getter(comp, *, context):
+        _ = comp
+        _ = context
+        return "ok"
+
+    result = resolve_getter(passthrough_getter)
+    assert result.is_ok()
+    assert result.unwrap() is passthrough_getter

--- a/tests/test_rule_filter.py
+++ b/tests/test_rule_filter.py
@@ -222,13 +222,38 @@ def test_rulefilter_model_validator_both_any_of_and_all_of_error():
 
 
 def test_rulefilter_model_validator_leaf_field_required():
-    """RuleFilter.field required for leaf filters."""
+    """RuleFilter.field required for field-backed leaf filters."""
     import pytest
 
     from r2x_core import RuleFilter
 
     with pytest.raises(ValueError, match="field is required for leaf filters"):
         RuleFilter(op="eq", values=["gas"])
+
+
+def test_rulefilter_model_validator_getter_leaf():
+    """RuleFilter accepts getter-backed leaf filters."""
+    from rust_ok import Ok
+
+    from r2x_core import RuleFilter
+
+    def resolve_fuel_type(_src: object, *, context: object):
+        _ = context
+        return Ok("gas")
+
+    filt = RuleFilter(getter=resolve_fuel_type, op="eq", values=["gas"])
+
+    assert filt.getter is resolve_fuel_type
+
+
+def test_rulefilter_model_validator_rejects_field_and_getter():
+    """RuleFilter cannot specify both field and getter on a leaf."""
+    import pytest
+
+    from r2x_core import RuleFilter
+
+    with pytest.raises(ValueError, match="cannot set both field and getter"):
+        RuleFilter(field="kind", getter=lambda *_args, **_kwargs: None, op="eq", values=["gas"])
 
 
 def test_rulefilter_model_validator_leaf_op_required():

--- a/tests/test_rule_filter.py
+++ b/tests/test_rule_filter.py
@@ -246,6 +246,26 @@ def test_rulefilter_model_validator_getter_leaf():
     assert filt.getter is resolve_fuel_type
 
 
+def test_rulefilter_model_validator_string_getter_resolves_registry_name():
+    """RuleFilter resolves registered getter names to callables."""
+    from rust_ok import Ok
+
+    from r2x_core import RuleFilter
+    from r2x_core.getters import GETTER_REGISTRY, getter
+
+    getter_name = "rulefilter_string_getter"
+    if getter_name not in GETTER_REGISTRY:
+
+        @getter(name=getter_name)
+        def rulefilter_string_getter(_src, *, context):
+            _ = context
+            return Ok("gas")
+
+    filt = RuleFilter(getter=getter_name, op="eq", values=["gas"])
+
+    assert callable(filt.getter)
+
+
 def test_rulefilter_model_validator_rejects_field_and_getter():
     """RuleFilter cannot specify both field and getter on a leaf."""
     import pytest

--- a/tests/test_rule_filter.py
+++ b/tests/test_rule_filter.py
@@ -276,6 +276,16 @@ def test_rulefilter_model_validator_rejects_field_and_getter():
         RuleFilter(field="kind", getter=lambda *_args, **_kwargs: None, op="eq", values=["gas"])
 
 
+def test_rulefilter_model_validator_rejects_non_string_non_callable_getter():
+    """RuleFilter getter accepts only callables or strings."""
+    import pytest
+
+    from r2x_core import RuleFilter
+
+    with pytest.raises(TypeError, match="callable or str"):
+        RuleFilter(getter=123, op="eq", values=["gas"])
+
+
 def test_rulefilter_model_validator_leaf_op_required():
     """RuleFilter.op required for leaf filters."""
     import pytest

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -132,6 +132,15 @@ def test_rule_from_records_processes_string_getters_and_filters():
     from rust_ok import Ok
 
     from r2x_core import Rule, RuleFilter
+    from r2x_core.getters import GETTER_REGISTRY, getter
+
+    filter_getter_name = "rule_filter_record_getter"
+    if filter_getter_name not in GETTER_REGISTRY:
+
+        @getter(name=filter_getter_name)
+        def rule_filter_record_getter(_src, *, context):
+            _ = context
+            return Ok("ok")
 
     records = [
         {
@@ -140,7 +149,7 @@ def test_rule_from_records_processes_string_getters_and_filters():
             "version": 1,
             "field_map": {"name": "name"},
             "getters": {"nested_name": "child.name"},
-            "filter": {"field": "status", "op": "eq", "values": ["ok"]},
+            "filter": {"getter": filter_getter_name, "op": "eq", "values": ["ok"]},
         }
     ]
 
@@ -148,6 +157,7 @@ def test_rule_from_records_processes_string_getters_and_filters():
     assert len(rules) == 1
     rule = rules[0]
     assert isinstance(rule.filter, RuleFilter)
+    assert callable(rule.filter.getter)
     getter_fn = rule.getters["nested_name"]
     if callable(getter_fn):
         result = getter_fn(SimpleNamespace(child=SimpleNamespace(name="x")), context=None)

--- a/tests/test_rules_dependencies.py
+++ b/tests/test_rules_dependencies.py
@@ -244,6 +244,25 @@ def test_topological_sort_unknown_dependency():
     assert "unknown rule" in str(result.err()).lower()
 
 
+def test_topological_sort_unnamed_unknown_dependency():
+    """Unnamed rules with unknown dependencies are rejected."""
+    from r2x_core import Rule
+    from r2x_core.rules_executor import sort_rules_by_dependencies
+
+    unnamed_rule = Rule(
+        source_type="A",
+        target_type="B",
+        version=1,
+        field_map={"f": "f"},
+        depends_on=["missing_named_rule"],
+    )
+
+    result = sort_rules_by_dependencies([unnamed_rule])
+
+    assert result.is_err()
+    assert "unknown rule" in str(result.err()).lower()
+
+
 def test_topological_sort_duplicate_names():
     """Duplicate rule names are detected."""
     from r2x_core import Rule

--- a/tests/test_rules_executor.py
+++ b/tests/test_rules_executor.py
@@ -13,6 +13,7 @@ from r2x_core import (
     PluginConfig,
     PluginContext,
     Rule,
+    RuleFilter,
     System,
     apply_rules_to_context,
     apply_single_rule,
@@ -109,6 +110,59 @@ def test_apply_single_rule_missing_source_attribute(source_system, target_system
     result = apply_single_rule(rule, context=context)
     assert result.is_err()
     assert "No attribute" in str(result.err())
+
+
+def test_apply_single_rule_getter_filter_uses_context(source_system, target_system):
+    """Getter-backed filters can select components using PluginContext data."""
+    from rust_ok import Ok
+
+    def selected_fuel_type(src, *, context):
+        if src.name != context.metadata["selected_name"]:
+            return Ok("coal")
+        return Ok(context.metadata["selected_fuel_type"])
+
+    rule = Rule(
+        source_type="PlantComponent",
+        target_type="StationComponent",
+        version=1,
+        field_map={"name": "name", "uuid": "uuid"},
+        filter=RuleFilter(getter=selected_fuel_type, op="eq", values=["gas"]),
+    )
+    context = _build_context(
+        rules=[rule],
+        source_system=source_system,
+        target_system=target_system,
+    ).evolve(metadata={"selected_name": "plant_alpha", "selected_fuel_type": "gas"})
+
+    result = apply_single_rule(rule, context=context)
+    assert result.is_ok()
+    assert result.unwrap().converted == 1
+
+
+def test_apply_single_rule_getter_filter_failure(source_system, target_system):
+    """Getter failures bubble out as rule failures instead of matches."""
+    from rust_ok import Err
+
+    def faulty_filter(_src, *, context):
+        _ = context
+        return Err(ValueError("boom"))
+
+    rule = Rule(
+        source_type="PlantComponent",
+        target_type="StationComponent",
+        version=1,
+        field_map={"name": "name", "uuid": "uuid"},
+        filter=RuleFilter(getter=faulty_filter, op="eq", values=["gas"]),
+    )
+    context = _build_context(
+        rules=[rule],
+        source_system=source_system,
+        target_system=target_system,
+    )
+
+    result = apply_single_rule(rule, context=context)
+    assert result.is_err()
+    assert "Failed to evaluate filter" in str(result.err())
 
 
 def test_attach_component_supplemental_attribute_target_missing(source_system):

--- a/tests/test_rules_utils.py
+++ b/tests/test_rules_utils.py
@@ -290,6 +290,48 @@ def test_evaluate_rule_filter_all_of():
     assert not evaluate_rule_filter(FailComponent(), rule_filter=filt)
 
 
+def test_evaluate_rule_filter_getter_uses_context(context_example):
+    """Getter-backed filters can use PluginContext-derived values."""
+    from rust_ok import Ok
+
+    from r2x_core import RuleFilter
+    from r2x_core.utils import evaluate_rule_filter
+
+    class Component:
+        name = "plant_alpha"
+        fuel_type = "gas"
+
+    def select_fuel(src, *, context):
+        if src.name != context.metadata["selected_name"]:
+            return Ok("coal")
+        return Ok(context.metadata["selected_fuel"])
+
+    filt = RuleFilter(getter=select_fuel, op="eq", values=["gas"])
+    ctx = context_example.evolve(metadata={"selected_name": "plant_alpha", "selected_fuel": "gas"})
+
+    assert evaluate_rule_filter(Component(), rule_filter=filt, context=ctx)
+
+
+def test_evaluate_rule_filter_getter_failure_raises(context_example):
+    """Getter-backed filters surface failures instead of matching silently."""
+    from rust_ok import Err
+
+    from r2x_core import RuleFilter
+    from r2x_core.utils import evaluate_rule_filter
+
+    class Component:
+        name = "plant_alpha"
+
+    def faulty_getter(_src, *, context):
+        _ = context
+        return Err(ValueError("boom"))
+
+    filt = RuleFilter(getter=faulty_getter, op="eq", values=["gas"])
+
+    with pytest.raises(ValueError, match="Getter for RuleFilter failed: boom"):
+        evaluate_rule_filter(Component(), rule_filter=filt, context=context_example)
+
+
 def test_evaluate_rule_filter_incomplete_raises():
     """Test evaluate_rule_filter raises on incomplete leaf filter."""
     from r2x_core import RuleFilter

--- a/tests/test_rules_utils.py
+++ b/tests/test_rules_utils.py
@@ -332,6 +332,22 @@ def test_evaluate_rule_filter_getter_failure_raises(context_example):
         evaluate_rule_filter(Component(), rule_filter=filt, context=context_example)
 
 
+def test_evaluate_rule_filter_getter_requires_context():
+    """Getter-backed filters reject evaluation without context."""
+    import pytest
+
+    from r2x_core import RuleFilter
+    from r2x_core.utils import evaluate_rule_filter
+
+    class Component:
+        name = "plant_alpha"
+
+    filt = RuleFilter(getter=lambda _src, *, context: "gas", op="eq", values=["gas"])
+
+    with pytest.raises(ValueError, match="getter-backed filters require PluginContext"):
+        evaluate_rule_filter(Component(), rule_filter=filt)
+
+
 def test_evaluate_rule_filter_incomplete_raises():
     """Test evaluate_rule_filter raises on incomplete leaf filter."""
     from r2x_core import RuleFilter


### PR DESCRIPTION
Summary
- Implements getter-backed rule filters for issue #107.
- `RuleFilter` now accepts getter-backed leaves, resolves registered getter names at load time, and supports context-aware evaluation.
- Filter execution now passes `PluginContext` into getter-backed filters, and getter failures surface as rule errors instead of silent matches.
- Getter typing was tightened so the filter model keeps a callable-only contract internally.
- The public `resolve_getter` helper is exported for consumers that need the same getter resolution behavior as the loader.
- Documentation now includes concrete getter-backed filter examples, usage guidance, and a public API reference for `resolve_getter`.
- Additional tests cover the public getter resolver, missing-context behavior, and dependency edge cases so the new paths are exercised by real coverage.

Acceptance criteria
- [x] RuleFilter supports a getter-backed leaf filter shape for context-aware candidate value resolution.
  - Evidence: `src/r2x_core/rules.py`, `src/r2x_core/utils/rules.py`
- [x] Field-backed leaf filters remain backward compatible, including current `field`, `op`, `values`, `prefixes`, `casefold`, `on_missing`, `any_of`, and `all_of` behavior.
  - Evidence: Existing field-filter tests still pass, and leaf/composition validation remains intact.
- [x] Getter-backed filters can be loaded from records using registered getter names.
  - Evidence: `Rule.from_records()` test covers string getter resolution in `tests/test_rules.py`.
- [x] Getter-backed filters receive the source component and `PluginContext`.
  - Evidence: `evaluate_rule_filter(..., context=...)` passes context into getter-backed leaves.
- [x] Getter-backed filters can select components based on values derived from `PluginContext`.
  - Evidence: executor and utility tests cover context-dependent selection.
- [x] Getter failure is surfaced consistently with existing getter error handling and is not silently treated as a successful match.
  - Evidence: `tests/test_rules_utils.py` and `tests/test_rules_executor.py` cover getter failure paths.
- [x] Existing standalone field-filter behavior, including `RuleFilter.matches(component)`, remains compatible for field-backed filters.
  - Evidence: existing field-filter tests remain green.
- [x] Documentation or examples explain when to use a field-backed filter versus a getter-backed filter.
  - Evidence: `docs/source/how-tos/create-rule-filters.md`, `docs/source/how-tos/define-rule-mappings.md`, `docs/source/references/api.md`

Deviations from the original plan
- The implementation resolves string getter specs through the existing getter preprocessing path, so the loader accepts registered getter names and dotted attribute paths.
- A follow-up cleanup tightened the getter typing so the filter model keeps a callable-only contract internally.
- Documentation was expanded to include concrete getter-backed filter examples, usage guidance, and a public API reference for `resolve_getter` after the first pass was called out as too thin.
- Some defensive branches were simplified out of the hot path once they were shown to be unreachable in normal use.

Testing Strategy
- `uv run pytest -q -o addopts='' tests/test_getter.py tests/test_rule_filter.py tests/test_rules.py tests/test_rules_utils.py tests/test_rules_executor.py tests/test_rules_dependencies.py tests/test_docs_coverage.py`
- `just lint src/r2x_core tests`
- `just type`
- `uv sync --group docs`
- `just docs`

References
- Issue #107: https://github.com/NatLabRockies/r2x-core/issues/107
- Branch: `work/107-support-getter-backed-rule`
