### PR TITLE
feat: lossless translation history (lens complement, forward capture)

### DIFF
--- a/docs/source/explanations/index.md
+++ b/docs/source/explanations/index.md
@@ -11,6 +11,7 @@ plugin-system
 unit-system
 h5-readers
 rules-system
+lossless-translation
 data-management
 versioning
 ```

--- a/docs/source/explanations/lossless-translation.md
+++ b/docs/source/explanations/lossless-translation.md
@@ -1,0 +1,233 @@
+# Lossless Round-Trip Translation
+
+Translating a system from model X to model Y is inherently lossy. This
+document explains how R2X Core captures everything a forward translation
+discards, through an opt-in *translation history*, and the lens semantics that
+govern what a future reverse translation can restore.
+
+For the task-oriented guide, see {doc}`../how-tos/round-trip-translations`.
+
+```{note}
+The **forward capture** described here (the "get" half) is implemented: with
+`preserve_source=True`, a translation records a self-contained
+`translation_history` on the target system. The **reverse restoration** (the
+"put" half) is not yet implemented. The history carries everything a reverse
+pass needs; consuming it to reconstruct the source is future work. Where this
+document describes restoration, it describes the design the captured data is
+built to support, not current behavior.
+```
+
+## What Gets Lost in Translation
+
+A translation applies {py:class}`~r2x_core.Rule` objects that copy or compute
+target fields from source components (see {doc}`./rules-system`). Anything the
+rules do not name is discarded. Loss falls into three distinct categories:
+
+1. **Unmapped fields.** The target model has no home for a source field (a
+   ReEDS-specific attribute with no PLEXOS equivalent). The component
+   translates, the field vanishes.
+2. **Dropped components.** No rule matches a component's type, or a rule
+   filter excludes it. The entire component vanishes, along with its
+   supplemental attributes and time series.
+3. **Lossy transformations.** A getter collapses two fields into one, rounds a
+   unit conversion, or coarsens an enum. The value arrives in the target, but
+   the original cannot be computed back from it.
+
+Without extra bookkeeping, a later Y→X translation cannot reconstruct the
+original system: the information simply is not in Y.
+
+## Lens Semantics
+
+The design follows the bidirectional-transformation ("lens") literature from
+programming language and database research. A lens is a pair of functions
+between a rich "source" and a reduced "view", designed together so that the
+pair is lossless even though the forward direction alone is lossy:
+
+- `get : S → V`, the forward transform. Allowed to discard information.
+- `put : (V, S) → S`, the backward transform. Takes the edited view **and the
+  original source**, and produces an updated source.
+
+The signature of `put` is the whole trick. A naive reverse function `V → S` is
+impossible to write correctly because the discarded information is not in V.
+The lens move is to stop pretending and hand `put` access to what `get` threw
+away.
+
+### The Laws
+
+What makes a lens a lens, rather than two arbitrary functions, is a pair of
+round-trip laws:
+
+- **GetPut**: `put(get(s), s) = s`. Translate forward, edit nothing, translate
+  back, and you get the original, exactly. This is the lossless-conversion
+  requirement stated as an equation.
+- **PutGet**: `get(put(v, s)) = v`. Whatever edits you made in the view
+  survive the trip back; the restore step is not allowed to clobber them by
+  "helpfully" restoring stale originals.
+
+These two laws are in tension (GetPut says "restore the original values",
+PutGet says "respect the view's edits"), and resolving that tension fixes the
+merge policy with no freedom left over: on the way back, **fields the target
+carried and the user edited take their current target values**, **fields the
+target carried but the user left untouched restore their original source
+value** (undoing a lossy transform), and **fields the target never carried
+restore from the captured snapshot**.
+
+### The Complement Formulation
+
+An equivalent phrasing maps directly onto the captured history. Instead of
+`put` taking the whole original source, factor `get` into two outputs:
+
+```text
+get(s)      = (v, c)    # the view, plus a "complement" c holding everything discarded
+put(v', c)  = s'        # reconstruct from the edited view and the complement
+```
+
+The complement `c` is precisely "the stuff X cared about that Y doesn't". In
+R2X Core terms: the rules engine is `get`, the translation history is the
+complement `c`, and a reverse translation is `put`. A worked example:
+
+```text
+BusComponent (X)                 NodeComponent (Y)          snapshot (complement)
+  name: "bus1"       --get-->      name: "bus1"               zone: "west"
+  voltage_kv: 230.0                kv_rating: 230.0           owner: "PSCo"
+  zone: "west"
+  owner: "PSCo"
+                     user edits Y:  kv_rating = 345.0
+
+put(Y', c):  name        <- Y   (mapped)
+             voltage_kv  <- 345.0  (mapped; the edit survives, PutGet)
+             zone, owner <- snapshot (restored, GetPut)
+```
+
+This idea comes from database view-update theory (Bancilhon and Spyratos,
+1981, the "constant complement" approach); Foster, Pierce, and colleagues
+turned it into a compositional programming model ("Combinators for
+Bidirectional Tree Transformations", TOPLAS 2007, and the Boomerang language).
+
+### Two Refinements That Shape the Design
+
+**Symmetric lenses.** Classic lenses are asymmetric: the source is strictly
+richer and the view is a projection. Model translation is not like that; a
+PLEXOS model has fields Sienna lacks *and vice versa*, so neither side is "the
+source". The generalization (Hofmann, Pierce, and Wagner, 2011) keeps a
+complement on **both** sides. Practically, the mechanism is
+direction-agnostic: one hop record per translation run, produced the same way
+whether you are going X→Y or Y→X.
+
+**Chains, not just round trips.** Real usage is a chain,
+`X → Y → X → Z → Y`, with no privileged "original" model. Because each hop is
+one-shot (a model is not independently edited and merged back later), the
+history is a *line*: an append-only stack of hop records where no hop ever
+mutates or forgets a prior record. Returning to a model many hops later can
+still consult the earlier record that captured it. This is why the history is
+a `list` of records, not a single overwrite-per-hop blob.
+
+**Delta lenses and deletions.** State-based lenses make absence ambiguous: is
+a component missing from Y because it was deleted, or because it was never
+mapped? Each edge in a hop record carries a `status` that resolves this:
+`translated` (a target was produced), `dropped` (a rule matched but excluded
+it), or `unclaimed` (no rule ever named its type). A future reverse pass can
+resurrect `unclaimed`/`dropped` components while letting user deletions of
+`translated` components propagate.
+
+## The Translation History
+
+When a translation runs with `preserve_source=True` on the
+{py:class}`~r2x_core.PluginContext`, the executor appends one
+`HopRecord` to the target system's `translation_history`. A hop record is the
+lens complement for that hop. It holds:
+
+- **A full snapshot** of the source system, in the exact infrasys
+  serialization form the system JSON uses (each component and supplemental
+  attribute carries its `__metadata__` type discriminator). This means a
+  reverse pass reconstructs components through the same path
+  {py:meth}`~r2x_core.System.from_json` uses, so even models with computed-field
+  discriminators under `extra="forbid"` round-trip correctly.
+- **Correspondence edges.** Each `HopEdge` records `source_uuids` and
+  `target_uuids`, with arity as data: one-to-many (fan-out), many-to-one
+  (aggregation), and many-to-many are all just edges with plural sides. Each
+  edge carries the producing rule's name and version, and a `status`.
+- **A mapped-field baseline.** Per produced target, the as-produced values of
+  the fields the rule mapped, captured *after* validation. A reverse pass
+  compares a target's current value against this baseline to tell a user edit
+  (current ≠ baseline) from a lossy forward transform (current == baseline).
+
+Snapshots are full images rather than "just the leftover fields" deliberately.
+Getters are opaque callables that may read any source field, so the set of
+consumed fields cannot be computed reliably; and a full snapshot is
+self-contained, which is what makes it survive a cross-tool JSON handoff.
+
+### The Identity Tag
+
+Alongside the history, every translated target component gets a lightweight
+{py:class}`~r2x_core.SourceProvenance` supplemental attribute recording the
+UUID of the source component it came from. This is a cheap 1:1 identity index
+for "which source did this target come from"; it is *not* the complement. It
+rides in normal infrasys serialization with no sidecar keys.
+{py:meth}`~r2x_core.System.iter_translated_components` uses it to distinguish
+rule-produced components from pre-existing target content.
+
+### Where the History Lives
+
+The history is system-level state, serialized inside the system JSON under a
+`translation_history` key via
+{py:meth}`~r2x_core.System.serialize_system_attributes`, so it travels with the
+Y system through `to_json`/`from_json` and survives handoffs between tools.
+
+It is *not* stored as components inside the system on purpose: dropped
+components live only in the snapshot, never in the active model's component
+graph. This keeps the active model pristine, so exporters, component
+iteration, and the next translation's own bookkeeping see only the model they
+expect, never a smuggled-in foreign component.
+
+Systems without a history deserialize exactly as before, and serialization
+output is byte-for-byte unchanged whenever the feature is off (no extra keys
+are emitted).
+
+### Forward Compatibility
+
+Each hop record carries a `schema_version`. A record from a newer schema than
+the installed library (an unknown field, or a higher `schema_version`) fails
+validation on load and is retained *inertly*: the raw payload is kept so it
+survives a round trip at its original stack position, and the system still
+loads (a downstream tool must be able to open the file). Code that relies on
+the history for recovery must check
+{py:meth}`~r2x_core.System.has_unparsed_translation_history` and refuse to
+proceed when it returns `True`, rather than silently operating on a truncated
+stack. This is deliberate: silently dropping a record we cannot parse would
+turn a losslessness guarantee into silent loss.
+
+## Aggregation and the `consumes` Hook
+
+The executor observes one source component producing N target components
+(fan-out). It cannot see aggregation: a `system="target"` rule, or a getter
+that reaches into the system to fold in sibling components, consumes sources
+the executor's per-component loop never iterated. Those sources would be
+misclassified as `unclaimed`.
+
+To make aggregation visible, an aggregation rule declares what it folds in via
+{py:attr}`~r2x_core.Rule.consumes`: given the iterated component, it returns
+the additional source components consumed. The edge then records
+`source_uuids = [iterated, *consumed]`. This keeps arity as data on the edge
+while putting the knowledge where it lives, in the rule.
+
+## Known Limitations
+
+- **Reverse restoration is not implemented yet.** The history captures
+  everything a `put` pass needs, but the pass itself is future work.
+- **Time series for dropped components** are not yet carried into the target
+  store, so a resurrected dropped component would not find its series. (Time
+  series for *translated* components transfer normally by UUID.) This is a
+  known gap in the current capture.
+- **Fan-out edits merge back from one sibling.** When one source produced
+  several targets, a future reverse pass drives the restore from the first
+  surviving sibling; edits on the other siblings do not merge.
+- **Supplemental attributes cannot be rule sources**, so edits made to a
+  target's supplemental attributes would not flow back through reverse rules.
+
+## See Also
+
+- {doc}`../how-tos/round-trip-translations` for the task-oriented guide
+- {doc}`./rules-system` for the rule system this builds on
+- {py:class}`~r2x_core.PluginContext` API reference
+- {py:class}`~r2x_core.SourceProvenance` API reference

--- a/docs/source/explanations/plugin-system.md
+++ b/docs/source/explanations/plugin-system.md
@@ -152,19 +152,21 @@ configuration.
 
 #### Plugin Base Class
 
-Custom plugins inherit from `Plugin`:
+Custom plugins inherit from `Plugin` and implement lifecycle hooks. The base class invokes the implemented hooks in a fixed order: `on_validate`, `on_prepare`, `on_upgrade`, `on_build`, `on_transform`, `on_translate`, `on_export`, `on_cleanup`. Each hook returns a `rust_ok` `Result`; hooks that produce a system (`on_build`, `on_transform`, `on_translate`) have their `Ok` value assigned back onto the context (`on_translate` populates `ctx.target_system`).
 
 ```python
-from r2x_core import Plugin, PluginConfig, PluginContext
+from r2x_core import Plugin, PluginConfig, apply_rules_to_context
+from rust_ok import Ok
 
-class MyPlugin(Plugin):
-    """Custom plugin for data transformation."""
+class MyTranslator(Plugin[MyPluginConfig]):
+    """Translate a source system into a target model format."""
 
-    def apply(self, context: PluginContext) -> None:
-        """Apply plugin logic to context systems."""
-        source = context.source_system
-        target = context.target_system
-        # Custom logic here
+    def on_translate(self):
+        """Build the target system by applying the context's rules."""
+        result = apply_rules_to_context(self.ctx)
+        if not result.success:
+            result.summary()
+        return Ok(self.ctx.target_system)
 ```
 
 ### 3. Plugin Configuration
@@ -201,8 +203,8 @@ Plugins are called during the system transformation process:
 
 1. **Initialization**: Plugin receives configuration (PluginConfig subclass)
 2. **Context Creation**: PluginContext is created with source and target systems
-3. **Plugin Execution**: Plugin.apply(context) performs custom logic
-4. **Result**: Modified or new system is returned
+3. **Plugin Execution**: `Plugin.run()` invokes the implemented lifecycle hooks in order (`on_validate` through `on_cleanup`)
+4. **Result**: Hook return values are assigned onto the context (`on_build`/`on_transform` update `system`, `on_translate` updates `target_system`)
 
 ### Filter Application in Parsers
 

--- a/docs/source/explanations/rules-system.md
+++ b/docs/source/explanations/rules-system.md
@@ -47,45 +47,51 @@ def translate_model_c_to_model_b(component_c, target_system):
 This approach creates several problems. Adding a new target format requires
 writing new functions for every source format. Changes to source or target
 schemas require updating multiple locations. Testing becomes difficult because
-conversion logic is scattered across many functions. Operator precedence and
-evaluation order can become ambiguous as the number of translation paths grows.
+conversion logic is scattered across many functions.
 
 The rule system addresses these challenges through declarative specifications
 that separate the "what" from the "how." A {py:class}`~r2x_core.Rule` declares
 what transformation should happen. The
 {py:func}`~r2x_core.apply_rules_to_context` executor handles how to perform it.
 
-With the rule system, the same rules work for any source format:
+The same transformation expressed as a rule:
 
 ```python
-# Rule-based approach - single definition, works for all formats
+from r2x_core import Rule, RuleFilter, PluginContext, apply_rules_to_context
+
 translation_rule = Rule(
     name="translate_large_components",
     source_type="ComponentA",
     target_type="ComponentB",
+    version=1,
     filter=RuleFilter(
-        operation="all_of",
-        predicates=[
-            RuleFilter(field="type", operation="eq", values=["TypeA"]),
-            RuleFilter(field="capacity", operation="geq", values=[100.0]),
+        all_of=[
+            RuleFilter(field="type", op="eq", values=["TypeA"]),
+            RuleFilter(field="capacity", op="geq", values=[100.0]),
         ]
     ),
     field_map={
         "name": "name",
         "capacity": "capacity",
-        "type": lambda src: "TypeA_Translated",
         "location": "location",
-    }
+    },
 )
 
-# Apply to any source format - same rule works for all
-apply_rules_to_context(context, [translation_rule], model_a_components)
-apply_rules_to_context(context, [translation_rule], model_c_components)
-apply_rules_to_context(context, [translation_rule], model_x_components)
+# Rules travel on the context; the executor pulls components from
+# context.source_system and adds the converted ones to context.target_system.
+context = PluginContext(
+    config=config,
+    rules=(translation_rule,),
+    source_system=model_a_system,
+    target_system=target_system,
+)
+result = apply_rules_to_context(context)
 ```
 
 The rule system eliminates code duplication, makes translation logic explicit
-and testable, and enables configuration-driven translation.
+and testable, and enables configuration-driven translation: the same rule can
+be expressed as a JSON record and loaded with
+{py:meth}`~r2x_core.Rule.from_records`.
 
 ## Core Design Principles
 
@@ -106,15 +112,14 @@ making translation logic configurable without code changes.
 
 Rather than embedding conditional logic within rules, the system uses composable
 {py:class}`~r2x_core.RuleFilter` objects to restrict which components a rule
-processes. A filter can match components by field values, by name prefixes, or
-by complex boolean combinations using `any_of` and `all_of`.
+processes. A filter can match components by field values, by derived values
+computed through getters, or by boolean combinations using `any_of` and
+`all_of`.
 
 Filters are separate objects that rules reference, enabling reuse across
 multiple rules. A filter matching "all generators with capacity above 100 MW in
 region 'West'" can be defined once and applied to multiple translation rules.
-Changes to selection criteria require updating only the filter definition. This
-composition avoids the combinatorial explosion that would result from hardcoding
-each source/target/filter combination.
+Changes to selection criteria require updating only the filter definition.
 
 ### Immutability for Correctness
 
@@ -126,9 +131,9 @@ that was defined, making behavior reproducible and debugging straightforward.
 
 The immutability constraint also enables safe sharing of rules across threads
 and processes. Concurrent translation operations cannot interfere with each
-other through shared mutable state. This is particularly important in enterprise
-environments where translation pipelines run continuously on large numbers of
-systems.
+other through shared mutable state. Rule identity (equality and hashing) is
+keyed on `(source_type, target_type, version)`, so two rules for the same
+conversion must declare distinct versions.
 
 ## Architecture Overview
 
@@ -136,12 +141,11 @@ systems.
 
 The {py:class}`~r2x_core.Rule` class encapsulates a single transformation
 between source and target types. Each rule specifies the source component type
-(or types) it matches, the target type (or types) it produces, and a version
-number for schema evolution. The `field_map` dictionary describes how source
-fields become target fields, supporting both simple one-to-one mappings and
-complex multi-field derivations through getter functions.
+it matches, the target type (or types) it produces, and an integer `version`
+for schema evolution. The `field_map` dictionary maps target field names to
+source field names for direct copies; anything computed goes in `getters`.
 
-Here's a simple example converting a model_a generator to a model_b generator:
+A simple rule using only direct field mappings:
 
 ```python
 from r2x_core import Rule
@@ -154,16 +158,30 @@ rule = Rule(
     field_map={
         "name": "name",
         "capacity_mw": "capacity_mw",
-        "fuel_type": lambda src: src.fuel_type.lower(),  # Transform fuel type
         "location": "location",
     },
-    defaults={"fuel_type": "natural_gas"},  # Fallback if fuel is missing
+    defaults={"fuel_type": "natural_gas"},  # Fallback when the source lacks a value
 )
 ```
 
-A more complex example showing multi-field derivation:
+A rule that derives target fields from computation uses `getters`. A getter is
+a callable receiving the source component and the active
+{py:class}`~r2x_core.PluginContext` as a keyword argument, returning a
+`rust_ok` `Result`:
 
 ```python
+from rust_ok import Ok
+from r2x_core import Rule
+
+
+def total_capacity(src, *, context):
+    return Ok(src.max_capacity * src.unit_count)
+
+
+def ramp_rate_per_minute(src, *, context):
+    return Ok(src.ramp_up_rate * 60)
+
+
 rule = Rule(
     name="model_a_to_model_b_generator_advanced",
     source_type="GeneratorA",
@@ -171,172 +189,187 @@ rule = Rule(
     version=1,
     field_map={
         "name": "name",
-        "capacity_mw": lambda src: src.max_capacity * src.unit_count,
         "min_up_time_hours": "min_online_time",
-        "ramp_rate_mw_per_minute": lambda src: src.ramp_up_rate * 60,
     },
-    depends_on=["generator_location_mapping"],  # Wait for other rules
+    getters={
+        "capacity_mw": total_capacity,
+        "ramp_rate_mw_per_minute": ramp_rate_per_minute,
+    },
+    depends_on=["generator_location_mapping"],  # Run after other rules
 )
 ```
 
-Rules support several advanced features. The `defaults` parameter provides
-fallback values when source fields are missing, enabling translation from
-simpler models that lack detail. The `depends_on` parameter ensures rules
-execute in the correct order when target fields come from previously translated
-components. The `filter` parameter references a {py:class}`~r2x_core.RuleFilter`
-that restricts which source components the rule processes.
+Getters can also be referenced by name. Functions decorated with
+{py:func}`~r2x_core.getter` register under their name (or a custom one), and
+JSON rule records can then reference them as strings; dotted strings fall back
+to nested attribute lookups. This keeps computed mappings available to fully
+configuration-driven rules.
+
+Field values are resolved with a fixed precedence: `field_map` reads the source
+attribute directly, `getters` compute values, and `defaults` (keyed by target
+field name) fill in whenever the mapped attribute is missing or the getter
+returns nothing. A mapped field that is missing on the source with no default
+is an error that fails the rule.
+
+A few structural constraints keep rules unambiguous. A rule may declare
+multiple target types (fan-out: one source component produces one target
+component per type) or multiple source types, but not both. A `field_map` entry
+whose source side is a list of fields requires a matching getter to combine
+them. The `system` parameter (default `"source"`) selects which system the rule
+reads from; `system="target"` lets a rule derive components from already
+translated ones.
 
 ### Filter Predicates
 
 The {py:class}`~r2x_core.RuleFilter` class provides a flexible predicate
-language for component selection. Leaf filters compare a component field against
-values using operations like equality, membership, numeric comparison, or prefix
-matching. Compound filters combine multiple predicates with `any_of` (OR) or
-`all_of` (AND) semantics.
-
-Here are some practical filter examples:
+language for component selection. Leaf filters compare a candidate value
+against `values` using one of: `eq`, `neq`, `in`, `not_in`, `geq`,
+`startswith`, `not_startswith`, `endswith`. Compound filters nest other filters
+under `any_of` (OR) or `all_of` (AND).
 
 ```python
 from r2x_core import RuleFilter
 
 # Simple equality filter
-filter_type_a = RuleFilter(
-    field="component_type",
-    operation="eq",
-    values=["TypeA"]
-)
+filter_type_a = RuleFilter(field="component_type", op="eq", values=["TypeA"])
 
-# Multiple values (membership)
+# Membership
 filter_multiple_types = RuleFilter(
-    field="component_type",
-    operation="in",
-    values=["TypeA", "TypeB", "TypeC"]
+    field="component_type", op="in", values=["TypeA", "TypeB", "TypeC"]
 )
 
-# Numeric comparison - components above 100 capacity
-filter_large = RuleFilter(
-    field="capacity",
-    operation="geq",
-    values=[100.0]
-)
+# Numeric comparison - components with capacity >= 100
+filter_large = RuleFilter(field="capacity", op="geq", values=[100.0])
 
-# Prefix matching - all components starting with "Region1"
-filter_region = RuleFilter(
-    field="name",
-    operation="startswith",
-    values=["Region1"]
-)
+# Prefix matching uses the dedicated `prefixes` field
+filter_region = RuleFilter(field="name", op="startswith", prefixes=["Region1"])
 
-# Complex combinations
+# AND composition
 filter_large_type_a = RuleFilter(
-    operation="all_of",
-    predicates=[
-        RuleFilter(field="component_type", operation="eq", values=["TypeA"]),
-        RuleFilter(field="capacity", operation="geq", values=[50.0]),
+    all_of=[
+        RuleFilter(field="component_type", op="eq", values=["TypeA"]),
+        RuleFilter(field="capacity", op="geq", values=[50.0]),
     ]
 )
 
-# OR combinations - TypeA OR TypeB
+# OR composition
 filter_common_types = RuleFilter(
-    operation="any_of",
-    predicates=[
-        RuleFilter(field="component_type", operation="in", values=["TypeA", "TypeB"]),
-        RuleFilter(field="component_type", operation="eq", values=["TypeC"]),
+    any_of=[
+        RuleFilter(field="component_type", op="in", values=["TypeA", "TypeB"]),
+        RuleFilter(field="component_type", op="eq", values=["TypeC"]),
     ]
 )
 ```
 
+The candidate value normally comes from a component attribute (`field`), but a
+filter can instead declare a `getter` to derive it from translator context,
+supplemental attributes, or other source-system lookups. Two more knobs control
+edge cases: `casefold` (default true) makes string comparison
+case-insensitive, and `on_missing` decides whether a component lacking the
+field is included or excluded (default `"exclude"`).
+
 The filter implementation optimizes for repeated evaluation. String values are
 casefolded once during filter construction rather than on every comparison.
-Prefix lists are cached in normalized form. These optimizations matter when
-filtering thousands of components during a large system translation.
+These optimizations matter when filtering thousands of components during a
+large system translation. See {doc}`../how-tos/create-rule-filters` for the
+full how-to, including getter-backed filters loaded from JSON records.
 
 ### Rule Execution
 
 The {py:func}`~r2x_core.apply_rules_to_context` function orchestrates the
-translation process. It first validates rules for consistency, checking for
-duplicate names and unresolved dependencies. Rules are then topologically sorted
-so that dependencies execute before dependents. Each rule is applied to all
-matching source components, creating target components that are added to the
-target system.
-
-Here's how to apply rules to translate components:
+translation. It takes only the {py:class}`~r2x_core.PluginContext`; rules,
+source system, and target system all travel on the context:
 
 ```python
-from r2x_core import apply_rules_to_context, Rule, PluginContext
+from r2x_core import Rule, PluginContext, apply_rules_to_context
 
-# Define rules for translation
-rules = [
+rules = (
     Rule(
         name="translate_component_type_a",
         source_type="ComponentA",
         target_type="ComponentB",
         version=1,
-        field_map={
-            "name": "name",
-            "capacity": "capacity",
-            "location": "location",
-        }
+        field_map={"name": "name", "capacity": "capacity", "location": "location"},
     ),
     Rule(
         name="translate_component_type_b",
         source_type="NodeA",
         target_type="NodeB",
         version=1,
-        field_map={
-            "name": "name",
-            "voltage": "voltage",
-        }
+        field_map={"name": "name", "voltage": "voltage"},
     ),
-]
+)
 
-# Apply rules within a plugin context
-result = apply_rules_to_context(
-    context=plugin_context,
+context = PluginContext(
+    config=config,
     rules=rules,
-    source_components=source_system.get_components(),
+    source_system=source_system,
+    target_system=target_system,
 )
+result = apply_rules_to_context(context)
 
-# Check results
-if result.is_complete():
-    print(f"Translation successful: {result.total_components} components")
+if result.success:
+    print(f"Translation successful: {result.total_converted} components")
 else:
-    print(f"Some translations failed:")
     for rule_result in result.rule_results:
-        if rule_result.is_err():
-            print(f"  {rule_result.rule_name}: {rule_result.error}")
+        if not rule_result.success:
+            print(f"  {rule_result.rule}: {rule_result.error}")
 ```
 
-For single-rule application with fine-grained control:
+Execution proceeds in well-defined stages:
 
-```python
-from r2x_core import apply_single_rule
+1. **Dependency sorting.** Rules are topologically sorted by their
+   `depends_on` declarations (Kahn's algorithm). Duplicate rule names,
+   unknown dependencies, and dependency cycles are rejected up front. Unnamed
+   rules without dependencies run first.
+2. **Per-rule application.** For each rule, the executor resolves the source
+   and target classes by name, iterates matching components from the system
+   selected by `rule.system`, evaluates the filter, builds target field values,
+   and constructs one target component per target type. A failing rule is
+   recorded in its {py:class}`~r2x_core.RuleResult` without aborting the
+   remaining rules.
+3. **UUID handling.** By convention, mapping `"uuid": "uuid"` in `field_map`
+   preserves the source component's identity on the target, which later stages
+   rely on. When a rule declares multiple target types, the executor assigns
+   each created component a fresh UUID instead, since several components cannot
+   share one identity.
+4. **Supplemental attribute attachment.** When a rule's target type is a
+   `SupplementalAttribute` subclass, the created attribute is attached to the
+   target component whose UUID matches the source component's UUID. The
+   component-producing rule must therefore run first (use `depends_on`) and
+   preserve the UUID.
+5. **Time series transfer.** After all rules have run,
+   {py:func}`~r2x_core.transfer_time_series_metadata` copies time series
+   associations in bulk, matching source and target components by equal UUID
+   and remapping child-owned series onto translated parents where needed. The
+   counts appear on the returned result as `time_series_transferred` and
+   `time_series_updated`.
 
-# Apply one rule to specific components
-result = apply_single_rule(
-    context=plugin_context,
-    rule=rules[0],
-    source_components=source_system.get_components()[:10],  # First 10 only
-)
-
-if result.is_ok():
-    created = result.value()
-    target_system.add_components(created)
-```
-
-The function returns a {py:class}`~r2x_core.TranslationResult` containing
-detailed statistics. Individual rule outcomes are captured in
-{py:class}`~r2x_core.RuleResult` objects, providing visibility into what
-succeeded, what failed, and why. This detailed reporting enables debugging of
-translation workflows and monitoring of translation quality.
+The function returns a {py:class}`~r2x_core.TranslationResult` with aggregate
+statistics (`total_rules`, `successful_rules`, `failed_rules`,
+`total_converted`, the per-rule `rule_results`, and the time series counters).
+Its `success` property is true when no rule failed, and `summary()` prints a
+formatted table for logging and debugging.
 
 ### Single-Rule Application
 
 The {py:func}`~r2x_core.apply_single_rule` function handles translation for a
-single rule. It resolves source and target types, evaluates filters, builds
-target field values, and creates target components. This function is useful when
-you need fine-grained control over the translation process or want to apply
-rules selectively outside the full workflow.
+single rule, useful for fine-grained control or selective application outside
+the full workflow:
+
+```python
+from r2x_core import apply_single_rule
+from rust_ok import Ok, Err
+
+match apply_single_rule(rule, context=context):
+    case Ok(stats):
+        print(f"converted={stats.converted} skipped={stats.skipped}")
+    case Err(error):
+        print(f"rule failed: {error}")
+```
+
+It returns a `Result[RuleApplicationStats, ValueError]` rather than raising,
+consistent with the `rust_ok` error handling used across the executor.
 
 ## Design Trade-offs
 
@@ -355,10 +388,10 @@ rule objects are rarely modified after creation, making this cost acceptable.
 Rules reference source and target types by string name rather than actual Python
 classes. This design enables rules to be defined in JSON configuration files
 where class objects cannot be represented. The executor resolves strings to
-classes at runtime using the {py:class}`~r2x_core.PluginContext` model registry.
-This late binding adds flexibility but means type errors are caught at execution
-rather than definition time. The trade-off favors runtime flexibility for
-configuration-driven use cases.
+classes at runtime by searching the modules listed in the context's
+`config.models`. This late binding adds flexibility but means type errors are
+caught at execution rather than definition time. The trade-off favors runtime
+flexibility for configuration-driven use cases.
 
 ### Why Separate Filters from Rules?
 
@@ -374,9 +407,12 @@ pushdown.
 
 Rules integrate with the broader plugin system through the
 {py:class}`~r2x_core.PluginContext`. The context provides access to source and
-target systems, configuration, and the model registry for type resolution.
+target systems, configuration, and the model modules used for type resolution.
 Translation plugins define rules as part of their configuration and invoke the
-rule executor during the `on_translate` lifecycle hook.
+rule executor during the `on_translate` lifecycle hook. The context also
+exposes lookup helpers (`list_rules`, `get_rule`, `get_rules_for_source`,
+`list_available_conversions`) so plugins can discover available conversions at
+runtime.
 
 This integration enables declarative plugin configuration. A translation plugin
 can be fully configured through JSON files specifying rules, filters, and field
@@ -389,8 +425,8 @@ expressed declaratively.
 The rule system is designed for large-scale translations involving thousands of
 components. Rule validation and dependency sorting happen once per translation,
 not per component. Filter predicates cache normalized values to avoid repeated
-computation. The executor minimizes object allocation by reusing context objects
-across rule applications.
+computation. Component classes are resolved once per rule rather than per
+component.
 
 For very large systems, the executor could be extended to parallelize
 independent rules. The current sequential execution is sufficient for typical
@@ -403,10 +439,10 @@ need for locking or synchronization.
 The rule system provides several extension points for future enhancement. Custom
 filter operations could be registered to extend the predicate language. Rule
 inheritance could allow base rules with shared mappings that derived rules
-extend. Bidirectional rules could support round-trip translation by defining
-both directions in a single specification. Transformation pipelines could
-combine rules from multiple plugins. These extensions would build on the
-existing architecture without fundamental changes.
+extend. Transformation pipelines could combine rules from multiple plugins.
+Round-trip (bidirectional) translation is addressed by the translation history
+described in {doc}`./lossless-translation`. These extensions build on
+the existing architecture without fundamental changes.
 
 ## Complete Example: ReEDS to Infrasys Translation
 
@@ -414,104 +450,97 @@ Here's a realistic example translating ReEDS model generators and buses to an
 Infrasys system:
 
 ```python
-from r2x_core import (
-    Rule, RuleFilter, apply_rules_to_context, PluginContext
-)
+from rust_ok import Ok
+from r2x_core import Rule, RuleFilter, PluginContext, apply_rules_to_context
 
-# Define filters for selective translation
-filter_wind = RuleFilter(field="fuel", operation="eq", values=["Wind"])
-filter_large = RuleFilter(field="p_max_mw", operation="geq", values=[100.0])
+# Filters for selective translation
 filter_large_wind = RuleFilter(
-    operation="all_of",
-    predicates=[filter_wind, filter_large]
+    all_of=[
+        RuleFilter(field="fuel", op="eq", values=["Wind"]),
+        RuleFilter(field="p_max_mw", op="geq", values=[100.0]),
+    ]
 )
 
-# Define translation rules
-rules = [
-    # Step 1: Translate all buses
+
+def wind_category(src, *, context):
+    return Ok("WindOnshore")
+
+
+rules = (
+    # Step 1: Translate all buses, preserving identity for later steps
     Rule(
         name="reeds_buses_to_infrasys",
         source_type="ReEDSBus",
         target_type="Bus",
         version=1,
         field_map={
+            "uuid": "uuid",
             "name": "name",
             "voltage_kv": "voltage_kv",
             "region": "region",
-        }
+        },
     ),
-
-    # Step 2: Translate large wind generators (depends on buses)
+    # Step 2: Translate large wind generators (after buses)
     Rule(
         name="reeds_wind_generators",
         source_type="ReEDSGenerator",
         target_type="Generator",
         version=1,
-        filter=filter_large_wind,  # Only generators >100MW with wind fuel
+        filter=filter_large_wind,
         field_map={
             "name": "name",
             "p_max_mw": "p_max_mw",
-            "fuel": lambda src: "WindOnshore",
             "zone_id": "zone",
             "min_up_time": "min_online_time_minutes",
         },
+        getters={"fuel": wind_category},
         depends_on=["reeds_buses_to_infrasys"],
     ),
-
     # Step 3: Translate conventional generators
     Rule(
         name="reeds_thermal_generators",
         source_type="ReEDSGenerator",
         target_type="ThermalGenerator",
         version=1,
-        filter=RuleFilter(
-            operation="any_of",
-            predicates=[
-                RuleFilter(field="fuel", operation="eq", values=["Coal"]),
-                RuleFilter(field="fuel", operation="eq", values=["Gas"]),
-            ]
-        ),
+        filter=RuleFilter(field="fuel", op="in", values=["Coal", "Gas"]),
         field_map={
             "name": "name",
             "p_max_mw": "p_max_mw",
             "fuel": "fuel",
             "heat_rate_mmbtu_per_mwh": "heat_rate",
         },
-        defaults={"heat_rate": 10.5},  # Default if missing
+        defaults={"heat_rate_mmbtu_per_mwh": 10.5},  # Keyed by target field
         depends_on=["reeds_buses_to_infrasys"],
     ),
-]
+)
 
-# Apply rules in order
 context = PluginContext(
+    config=config,
+    rules=rules,
     source_system=reeds_system,
     target_system=infrasys_system,
 )
 
-result = apply_rules_to_context(
-    context=context,
-    rules=rules,
-    source_components=reeds_system.components,
-)
+result = apply_rules_to_context(context)
 
-# Examine results
+result.summary()
 for rule_result in result.rule_results:
-    print(f"{rule_result.rule_name}:")
-    print(f"  Components processed: {rule_result.components_processed}")
-    print(f"  Successfully translated: {rule_result.components_translated}")
-    if rule_result.is_err():
-        print(f"  Error: {rule_result.error}")
+    status = "ok" if rule_result.success else f"error: {rule_result.error}"
+    print(f"{rule_result.rule}: converted={rule_result.converted} ({status})")
 ```
 
 This example demonstrates several key concepts: selective translation through
-filters, field transformation using lambda functions, default values for missing
-data, and ordered execution through dependencies. The same rule definitions could
-be stored in JSON and loaded from configuration files, enabling fully declarative
-translation pipelines.
+filters, computed fields using getters, default values for missing data, UUID
+preservation for cross-rule identity, and ordered execution through
+dependencies. The same rule definitions could be stored in JSON and loaded from
+configuration files with {py:meth}`~r2x_core.Rule.from_records`, enabling fully
+declarative translation pipelines.
 
 ## See Also
 
 - {doc}`../how-tos/define-rule-mappings` for practical usage examples
+- {doc}`../how-tos/create-rule-filters` for filter composition patterns
+- {doc}`./lossless-translation` for round-trip translation and the translation history
 - {doc}`./plugin-system` for understanding plugin integration
 - {py:class}`~r2x_core.Rule` API reference
 - {py:class}`~r2x_core.RuleFilter` API reference

--- a/docs/source/how-tos/apply-rules.md
+++ b/docs/source/how-tos/apply-rules.md
@@ -57,3 +57,4 @@ Use `apply_single_rule()` to apply one rule:
 
 - {doc}`create-rules` - Creating rules
 - {doc}`define-rule-mappings` - Rules overview and filter patterns
+- {doc}`round-trip-translations` - Preserving data for lossless reverse translation

--- a/docs/source/how-tos/create-rule-filters.md
+++ b/docs/source/how-tos/create-rule-filters.md
@@ -81,6 +81,18 @@ To negate the match, use `not_startswith`:
 }
 ```
 
+## Suffix-aware filters
+
+The `endswith` operator compares against string suffixes. Unlike the prefix operators, suffixes are supplied through the regular `values` field:
+
+```json
+{
+  "field": "name",
+  "op": "endswith",
+  "values": ["_dc", "_ac"]
+}
+```
+
 ## Composing filters
 
 Combine filters with `any_of`/`all_of` to express more subtle constraints:

--- a/docs/source/how-tos/define-rule-mappings.md
+++ b/docs/source/how-tos/define-rule-mappings.md
@@ -112,9 +112,14 @@ True
 >>> geq_filter = RuleFilter(field="count", op="geq", values=[3])
 >>> geq_filter.matches(component)
 True
+
+>>> # Suffix match
+>>> ends_filter = RuleFilter(field="name", op="endswith", values=["pha"])
+>>> ends_filter.matches(component)
+True
 ```
 
-Numeric comparisons like `geq`, `leq`, `gt`, and `lt` require exactly one value in the `values` list. The filter validates this constraint during construction.
+The full operator set is `eq`, `neq`, `in`, `not_in`, `geq`, `startswith`, `not_startswith`, and `endswith`. The only numeric comparison is `geq`, and it requires exactly one value in the `values` list; the filter validates this constraint during construction. For prefix matching with `startswith`/`not_startswith`, see {doc}`create-rule-filters`.
 
 ## Handle Missing Fields
 
@@ -261,12 +266,13 @@ The {py:meth}`~r2x_core.TranslationResult.summary` method prints a formatted tab
 Use {py:func}`~r2x_core.apply_rules_to_context` to apply all rules in a translation context:
 
 ```python doctest
->>> from r2x_core import Rule, apply_rules_to_context
->>> # rules = [rule1, rule2, rule3]
->>> # context = TranslationContext(rules=rules, source_components=[...])
+>>> from r2x_core import apply_rules_to_context
+>>> # context = PluginContext(config=config, rules=tuple(rules), source_system=source, target_system=target)
 >>> # result = apply_rules_to_context(context)
 >>> # result.total_converted contains the total number of components converted
 ```
+
+Rules are carried by the {py:class}`~r2x_core.PluginContext` itself; `apply_rules_to_context` takes only the context. Rules are topologically sorted by their `depends_on` declarations before execution, and time series metadata is transferred once after all rules have run.
 
 ## Apply a Single Rule
 
@@ -275,14 +281,17 @@ Apply one rule at a time using {py:func}`~r2x_core.apply_single_rule`:
 ```python doctest
 >>> from r2x_core import Rule, apply_single_rule
 >>> rule = Rule(source_type="Gen", target_type="Unit", version=1, field_map={"name": "name"})
->>> # result = apply_single_rule(rule, source_components=[...])
->>> # result.converted contains how many components were translated by this rule
+>>> # stats = apply_single_rule(rule, context=context).unwrap()
+>>> # stats.converted contains how many components this rule translated
 ```
+
+`apply_single_rule` returns a `Result[RuleApplicationStats, ValueError]` from `rust_ok`; unwrap it or pattern-match on `Ok`/`Err` to get the per-rule statistics.
 
 ## See Also
 
 - {doc}`../explanations/rules-system` for understanding rule system design decisions
 - {doc}`create-rule-filters` for advanced filter composition patterns
+- {doc}`round-trip-translations` for lossless round-trip translation
 - {doc}`./manage-versions` for handling rule versions
 - {py:class}`~r2x_core.Rule` API reference
 - {py:class}`~r2x_core.RuleFilter` API reference

--- a/docs/source/how-tos/index.md
+++ b/docs/source/how-tos/index.md
@@ -55,6 +55,7 @@ define-rule-mappings
 create-rules
 apply-rules
 create-rule-filters
+round-trip-translations
 ```
 
 ## Versioning

--- a/docs/source/how-tos/round-trip-translations.md
+++ b/docs/source/how-tos/round-trip-translations.md
@@ -1,0 +1,163 @@
+# Preserving Source Data Across Translations
+
+Capture everything a translation would otherwise discard, so the original
+source can be reconstructed later. This guide shows how to enable preservation,
+what gets captured, and how to inspect it. For the design and semantics, see
+{doc}`../explanations/lossless-translation`.
+
+```{note}
+This guide covers the **forward capture**, which is implemented. The **reverse
+restoration** that consumes the captured data to rebuild the source is not yet
+implemented; the captured history is built to support it as future work.
+```
+
+## Enable Preservation on the Translation
+
+Set `preserve_source=True` on the context. Everything else about applying
+rules stays the same (see {doc}`apply-rules`):
+
+```python
+from r2x_core import PluginContext, apply_rules_to_context
+
+context = PluginContext(
+    config=config,
+    rules=forward_rules,          # X -> Y rules
+    source_system=x_system,
+    target_system=y_system,
+    preserve_source=True,
+)
+result = apply_rules_to_context(context)
+```
+
+With preservation on, the executor does two things beyond the normal
+translation:
+
+- Tags every rule-produced target component with a
+  {py:class}`~r2x_core.SourceProvenance` supplemental attribute recording its
+  source UUID.
+- Appends one hop record to `y_system.translation_history` holding a full
+  snapshot of the source system, the source-to-target correspondence edges,
+  and a mapped-field baseline.
+
+## Inspect What Was Captured
+
+The captured history lives on the target system:
+
+```python
+record = y_system.translation_history[-1]
+
+record.source_system_uuid         # UUID of the source (X) system
+record.from_model, record.to_model
+len(record.snapshot.components)   # every source component, snapshotted
+record.edges                      # source-to-target correspondence
+```
+
+Each edge tells you how a source mapped, with arity as data:
+
+```python
+for edge in record.edges:
+    edge.source_uuids   # >1 for aggregation (many-to-one)
+    edge.target_uuids   # >1 for fan-out (one-to-many); [] when nothing produced
+    edge.status         # "translated", "dropped", or "unclaimed"
+    edge.rule_name, edge.rule_version
+```
+
+- `translated`: the rule produced at least one target component.
+- `dropped`: a rule matched the source but its filter excluded it.
+- `unclaimed`: no rule ever named the source's type. These, plus `dropped`
+  components, are the ones a reverse pass would resurrect.
+
+Find everything a translation discarded:
+
+```python
+discarded = [e for e in record.edges if e.status in ("dropped", "unclaimed")]
+```
+
+## Identify Translated Components
+
+Use {py:meth}`~r2x_core.System.iter_translated_components` to walk only the
+rule-produced components on the target (skipping any pre-existing target
+content):
+
+```python
+for component in y_system.iter_translated_components():
+    ...
+```
+
+## The History Travels with the System
+
+The history serializes inside the system JSON, so nothing extra needs to be
+saved or shipped:
+
+```python
+y_system.to_json("y_system.json")
+
+# Later, possibly in another process or tool
+from r2x_core import System
+y_system = System.from_json("y_system.json")
+y_system.translation_history            # restored intact
+```
+
+Before relying on the history for recovery, check that every record loaded
+cleanly. A record from a newer schema than the installed library is retained
+inertly rather than dropped, so recovery code must refuse to proceed if any
+record failed to parse:
+
+```python
+if y_system.has_unparsed_translation_history():
+    raise RuntimeError(
+        "translation history contains records this version cannot read; "
+        "upgrade r2x-core before attempting recovery"
+    )
+```
+
+## Declare Aggregation with `consumes`
+
+The executor sees one source producing many targets automatically. It cannot
+see aggregation, where a rule folds several source components into one target
+(via a `system="target"` rule or a getter that reaches into the system).
+Without help, the folded-in sources are recorded as `unclaimed`.
+
+Declare what an aggregation rule consumes so its correspondence is recorded
+correctly:
+
+```python
+from rust_ok import Ok
+
+def fold_in_siblings(iterated, *, context):
+    """Return the extra source components this rule aggregates."""
+    return [c for c in context.source_system.get_components(Sibling) if ...]
+
+rule = Rule(
+    source_type="Primary",
+    target_type="Aggregate",
+    version=1,
+    field_map={...},
+    consumes=fold_in_siblings,     # or a registered getter name (str)
+)
+```
+
+The producing edge then records `source_uuids = [iterated, *consumed]`.
+
+## When Preservation Is Off
+
+Without `preserve_source=True`, behavior is exactly as before: unmapped fields
+and unmatched components are dropped, no history is captured, and serialization
+output is byte-for-byte identical to a plain system. Existing translations are
+unaffected by this feature.
+
+## Limitations to Keep in Mind
+
+- Reverse restoration (rebuilding X from Y and the history) is not yet
+  implemented.
+- Time series for dropped/unclaimed components are not yet carried into the
+  target store, so a resurrected component would not find its series. Time
+  series for translated components transfer normally.
+
+See {doc}`../explanations/lossless-translation` for the full design.
+
+## See Also
+
+- {doc}`../explanations/lossless-translation` for design and semantics
+- {doc}`apply-rules` for applying rules to a context
+- {doc}`define-rule-mappings` for authoring rules

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -125,6 +125,29 @@ Complete API documentation for all r2x-core classes and functions.
    :members:
 ```
 
+```{eval-rst}
+.. autofunction:: r2x_core.apply_rules_to_context
+```
+
+```{eval-rst}
+.. autofunction:: r2x_core.apply_single_rule
+```
+
+```{eval-rst}
+.. autoclass:: r2x_core.TranslationResult
+   :members:
+```
+
+```{eval-rst}
+.. autoclass:: r2x_core.RuleResult
+   :members:
+```
+
+```{eval-rst}
+.. autoclass:: r2x_core.result.RuleApplicationStats
+   :members:
+```
+
 ## Getters
 
 ```{eval-rst}

--- a/docs/source/tutorials/plugin-context.md
+++ b/docs/source/tutorials/plugin-context.md
@@ -37,7 +37,7 @@ True
 | `system`                       | `System \| None`    | Optional | System object (created/modified) |
 | `source_system`                | `System \| None`    | Optional | Source for translation           |
 | `target_system`                | `System \| None`    | Optional | Output of translation            |
-| `rules`                        | `Sequence[Rule]`    | Optional | Transformation rules             |
+| `rules`                        | `tuple[Rule, ...]`  | Optional | Transformation rules             |
 | `metadata`                     | `dict[str, Any]`    | Optional | Arbitrary metadata               |
 | `skip_validation`              | `bool`              | Optional | Skip Pydantic validation         |
 | `auto_add_composed_components` | `bool`              | Optional | Auto-add composed components     |
@@ -204,6 +204,40 @@ target = System(name="sienna")
 ctx.target_system = target
 ctx.target_system.name
 'sienna'
+```
+
+### Inspecting Rules on the Context
+
+The context exposes lookup helpers so a plugin can discover which conversions are available without walking `ctx.rules` by hand:
+
+```python
+from r2x_core import PluginContext, PluginConfig, Rule
+
+class Config(PluginConfig):
+    pass
+
+rules = (
+    Rule(source_type="Bus", target_type="Node", version=1, field_map={"name": "name"}),
+    Rule(source_type="Generator", target_type="Unit", version=1, field_map={"name": "name"}),
+)
+ctx = PluginContext(config=Config(), rules=rules)
+
+ctx.list_rules()                          # all rules as a list
+ctx.get_rule("Bus", "Node")               # exact lookup, optionally by version
+ctx.get_rules_for_source("Generator")     # every rule consuming a source type
+ctx.list_available_conversions()          # (source_type, target_type, version) triples
+```
+
+### Deriving a New Context with evolve()
+
+When a step needs a modified context without mutating the shared one, `evolve()` copies the context with selected fields replaced. This is the copy-on-write mechanism behind the pipeline pattern:
+
+```python
+translated_ctx = ctx.evolve(target_system=target)
+translated_ctx is ctx
+False
+ctx.target_system is None  # original untouched
+True
 ```
 
 ## Creating Context from Command-Line Arguments

--- a/src/r2x_core/provenance.py
+++ b/src/r2x_core/provenance.py
@@ -1,21 +1,11 @@
 """Source-side provenance for lossless round-trip translations.
 
-When a translation runs with ``PluginContext.preserve_source=True``, we want a
-later reverse translation to reproduce the original source system. Two things
-have to survive the trip:
-
-1. The identity of every source component that was translated, so the reverse
-   pass can restore the original source UUIDs (needed for PutGet).
-2. Every source component (and supplemental attribute) that had no matching
-   translation rule, so the reverse pass can put them back.
-
-We record both by attaching a :class:`SourceProvenance` supplemental attribute
-to the relevant target-side entities:
-
-- Translated components get a ``SourceProvenance(preserved=False, source_uuid=...)``
-  pointing back at the source UUID they came from.
-- Untranslated source components (and their SAs) are copied into the target as
-  first-class components, tagged with ``SourceProvenance(preserved=True, ...)``.
+When a translation runs with ``PluginContext.preserve_source=True``, every
+translated target component is tagged with a :class:`SourceProvenance`
+supplemental attribute pointing back at the source component's UUID. This is a
+cheap 1:1 identity index ("which source did this target come from"); the full
+lens complement (dropped components, per-hop snapshots, correspondence edges,
+mapped-field baselines) lives in ``System.translation_history``.
 
 Because ``SourceProvenance`` is a real ``SupplementalAttribute``, it rides
 inside the standard infrasys serialization (JSON + sqlite associations) with
@@ -25,35 +15,32 @@ tag; nothing is hidden in an r2x-only side channel.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from infrasys import Component, SupplementalAttribute
-from infrasys.exceptions import ISAlreadyAttached
-from loguru import logger
-from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_serializer
+from packaging.version import Version
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
-from .utils import get_package_version
+from .translation_history import EdgeStatus, HopEdge, HopRecord, SystemSnapshot
+from .utils import VersionField, coerce_version, get_package_version
 
 if TYPE_CHECKING:
     from .system import System
 
 
 class SourceProvenance(SupplementalAttribute):
-    """Marks a target-side entity with its source-side provenance.
+    """Identity tag linking a translated target component to its source.
 
-    Two modes:
+    Attached to every rule-produced target component when
+    ``preserve_source=True``. It records the UUID of the source component the
+    target was translated from, so a later reverse translation can remap the
+    target's UUID back to its original source UUID (PutGet).
 
-    - ``preserved=False`` (translated): the tagged component was produced by a
-      translation rule from a source component with UUID ``source_uuid``. Used
-      on the reverse trip to remap Y-side UUIDs back to their original X-side
-      UUIDs (PutGet).
-    - ``preserved=True`` (carry-over): the tagged component is a copy of a
-      source component that no translation rule matched. It exists in the
-      target system solely so the reverse pass can put it back. The tagged
-      component's UUID equals ``source_uuid``.
+    This is deliberately a thin 1:1 index, not the lens complement. Everything
+    needed to reconstruct the source (dropped components, per-hop snapshots,
+    many-to-many correspondence edges, mapped-field baselines) lives in
+    ``System.translation_history``.
 
     ``SourceProvenance`` itself is a supplemental attribute, so it participates
     in normal infrasys serialization (persisted in ``supplemental_attributes``
@@ -61,41 +48,6 @@ class SourceProvenance(SupplementalAttribute):
     """
 
     source_uuid: UUID = Field(description="UUID of the originating source component")
-    preserved: Annotated[
-        bool,
-        Field(
-            description=(
-                "True if the tagged component is a carry-over from source that no rule translated. "
-                "False if the tagged component is a rule-produced translation of the source component."
-            )
-        ),
-    ]
-
-
-def _coerce_version(value: Any) -> Version:
-    """Accept a Version or PEP 440 string; raise a clear ValueError otherwise."""
-    if isinstance(value, Version):
-        return value
-    if isinstance(value, str):
-        try:
-            return Version(value)
-        except InvalidVersion as exc:
-            raise ValueError(f"{value!r} is not a valid PEP 440 version") from exc
-    raise TypeError(f"expected str or packaging.version.Version, got {type(value).__name__}")
-
-
-VersionField = Annotated[Version, BeforeValidator(_coerce_version)]
-
-
-def _preserve_uuid_collision_message(source_component: Component | SupplementalAttribute) -> str:
-    """Return a user-facing message for preserve-source UUID collisions."""
-    return (
-        f"Cannot preserve source component {source_component.label} "
-        f"(UUID={source_component.uuid}): target system already contains a "
-        f"component with that UUID. Target systems used with "
-        f"preserve_source=True should not be pre-populated with components "
-        f"that share UUIDs with untranslated source components."
-    )
 
 
 class ProvenanceInfo(BaseModel):
@@ -124,15 +76,18 @@ class ProvenanceInfo(BaseModel):
 
 
 class ProvenanceBuilder:
-    """Records source-to-target mappings during translation and preserves untranslated state.
+    """Captures the lens complement (a :class:`HopRecord`) during translation.
 
     Usage sits inside :func:`r2x_core.rules_executor.apply_rules_to_context`:
 
     1. Construct with the source system.
-    2. Call :meth:`record_translation` after each successful rule application.
-    3. Call :meth:`preserve_untranslated` after the rules loop to copy every
-       untranslated source component (and its SAs) into the target.
-    4. Call :meth:`finalize` to produce a :class:`ProvenanceInfo` for the
+    2. Call :meth:`record_translation` per produced target (attaches the cheap
+       1:1 identity tag).
+    3. Call :meth:`record_edge` per rule application (accumulates the
+       correspondence, with arity and mapped-field baseline).
+    4. Call :meth:`build_hop_record` after the rules loop to produce the full
+       hop record (snapshot + edges + unclaimed detection).
+    5. Call :meth:`finalize` to produce a :class:`ProvenanceInfo` for the
        target system's metadata.
     """
 
@@ -145,7 +100,16 @@ class ProvenanceBuilder:
             The source system being translated from.
         """
         self._source_system = source_system
-        self._translated_source_uuids: set[UUID] = set()
+        # Accumulated correspondence edges, one per rule application.
+        self._edges: list[HopEdge] = []
+        # Source UUIDs that at least one rule named (matched), whether it
+        # produced a target or deliberately dropped. Anything left over after
+        # all rules run is "unclaimed": no rule ever mentioned its type.
+        self._claimed_source_uuids: set[UUID] = set()
+        # target_uuid -> the mapped field names the producing rule declared, so
+        # the baseline captures only rule-produced fields (not defaults or
+        # computed fields the target happens to carry).
+        self._mapped_fields_by_target: dict[UUID, set[str]] = {}
 
     def record_translation(
         self,
@@ -155,19 +119,15 @@ class ProvenanceBuilder:
     ) -> None:
         """Tag a translated target component with its source-side UUID.
 
-        When ``target_component`` is a plain :class:`Component`: marks
-        ``source_component.uuid`` as translated (safe to repeat; the
-        underlying set is idempotent on membership) and attaches a fresh
-        :class:`SourceProvenance` tag to the target. Fan-out rules that
-        produce multiple targets from one source therefore end up with one
-        distinct tag per target, all pointing at the same source uuid.
+        When ``target_component`` is a plain :class:`Component`: attaches a
+        fresh :class:`SourceProvenance` tag to the target pointing at
+        ``source_component.uuid``. Fan-out rules that produce multiple targets
+        from one source therefore end up with one distinct tag per target, all
+        pointing at the same source uuid.
 
-        When ``target_component`` is a :class:`SupplementalAttribute`: no-op.
-        The source is deliberately NOT marked as translated so that a
-        source consumed only by SA-producing rules (no Component target)
-        still flows through the preservation pass and survives the reverse
-        trip. Any Component-producing rule that later consumes the same
-        source will still mark it via its own call to this method.
+        When ``target_component`` is a :class:`SupplementalAttribute`: no-op,
+        because SAs cannot own SAs. The correspondence for SA-producing rules
+        is captured in ``System.translation_history`` instead.
 
         Parameters
         ----------
@@ -182,73 +142,145 @@ class ProvenanceBuilder:
             The target system receiving the tag.
         """
         if isinstance(target_component, SupplementalAttribute):
-            # SAs can't own SAs. Do NOT mark the source as translated here:
-            # if the only rule that consumed this source produced an SA (no
-            # Component target), we still want the source itself to survive
-            # via the preservation pass so a reverse translation can put it
-            # back. Sources that also have Component-producing rules get
-            # marked by those rules' record_translation calls.
             return
 
-        self._translated_source_uuids.add(source_component.uuid)
-
-        provenance = SourceProvenance(
-            source_uuid=source_component.uuid,
-            preserved=False,
-        )
+        provenance = SourceProvenance(source_uuid=source_component.uuid)
         target_system.add_supplemental_attribute(target_component, provenance)
 
-    def preserve_untranslated(self, target_system: System) -> None:
-        """Copy untranslated source components (and their SAs) into the target.
+    def record_edge(
+        self,
+        *,
+        sources: list[Component | SupplementalAttribute],
+        targets: list[Component | SupplementalAttribute],
+        status: EdgeStatus,
+        rule_name: str | None = None,
+        rule_version: int | None = None,
+        mapped_fields: set[str] | None = None,
+    ) -> None:
+        """Record one source-to-target correspondence edge for the current hop.
 
-        Every source component whose UUID was not recorded via
-        :meth:`record_translation` is deep-copied into ``target_system`` (which
-        preserves its original UUID) and tagged with
-        ``SourceProvenance(preserved=True)``.
+        Arity is data: pass multiple ``sources`` for aggregation (many-to-one),
+        multiple ``targets`` for fan-out (one-to-many). All named sources are
+        marked claimed so they are not later misclassified as ``unclaimed``.
 
-        Every source SA that references at least one preserved component is
-        also deep-copied and re-attached, but only to owners that made it into
-        the target. Owners that were translated are skipped for that SA (their
-        translated counterparts get whatever SA the rules decided to produce).
+        Parameters
+        ----------
+        sources : list of Component or SupplementalAttribute
+            The source entities this edge consumed. Must be non-empty.
+        targets : list of Component or SupplementalAttribute
+            The target entities this edge produced. Empty for a drop.
+        status : EdgeStatus
+            ``"translated"`` when targets were produced, ``"dropped"`` when a
+            rule matched but deliberately produced nothing.
+        rule_name : str, optional
+            Name of the rule that produced this edge, if named.
+        rule_version : int, optional
+            Version of the rule that produced this edge.
+        mapped_fields : set of str, optional
+            Names of the target fields this rule actually produced (its
+            ``field_map`` and ``getters`` keys). Used to scope the baseline to
+            rule-produced fields. When ``None``, no baseline is captured for
+            these targets.
+        """
+        if not sources:
+            raise ValueError("record_edge requires at least one source")
+        source_uuids = [source.uuid for source in sources]
+        self._claimed_source_uuids.update(source_uuids)
+        if mapped_fields is not None:
+            for target in targets:
+                self._mapped_fields_by_target[target.uuid] = mapped_fields
+        self._edges.append(
+            HopEdge(
+                source_uuids=source_uuids,
+                target_uuids=[target.uuid for target in targets],
+                rule_name=rule_name,
+                rule_version=rule_version,
+                status=status,
+            )
+        )
 
-        Time series metadata for preserved components flows through the normal
-        :func:`transfer_time_series_metadata` path: preserved components live
-        in the target's ``_components_by_uuid`` under their original UUID, so
-        the sqlite transfer picks them up with no orphan-owner special case.
+    def build_hop_record(self, target_system: System) -> HopRecord:
+        """Assemble the hop record for this translation run.
+
+        Snapshots the whole source system (the lens complement), appends the
+        accumulated edges, adds one ``unclaimed`` edge per source component no
+        rule ever named, and captures the mapped-field baseline off the
+        constructed target components (post-validation).
 
         Parameters
         ----------
         target_system : System
-            The target system to preserve into.
+            The target system the translation produced. Used to read final,
+            validated target field values for the baseline.
+
+        Returns
+        -------
+        HopRecord
+            The self-contained complement for this hop.
         """
-        preserved_uuids: set[UUID] = set()
-        for source_component in self._iter_untranslated_source_components():
-            # deepcopy_component uses model_dump() then re-instantiates, so
-            # composed sub-components on `copy` are fresh instances that hold
-            # the same uuid as their source counterparts but do not point at
-            # the target-side canonical instance. Reverse translation will
-            # need to re-link composed refs by uuid; the executor's normal
-            # auto_add_composed_components path already de-duplicates by uuid
-            # so this does not corrupt the target's component graph.
-            copy = self._source_system.deepcopy_component(source_component)
-            try:
-                target_system.add_component(copy)
-            except ISAlreadyAttached as exc:
-                # Infrasys owns the canonical UUID uniqueness check. Keep the
-                # preserve-source-specific message while avoiding a duplicate
-                # preflight lookup for every preserved component.
-                raise ISAlreadyAttached(_preserve_uuid_collision_message(source_component)) from exc
-            provenance = SourceProvenance(
-                source_uuid=source_component.uuid,
-                preserved=True,
-            )
-            target_system.add_supplemental_attribute(copy, provenance)
-            preserved_uuids.add(source_component.uuid)
+        edges = list(self._edges)
+        edges.extend(
+            HopEdge(source_uuids=[source.uuid], target_uuids=[], status="unclaimed")
+            for source in self._source_system.iter_all_components()
+            if source.uuid not in self._claimed_source_uuids
+        )
 
-        if preserved_uuids:
-            logger.debug("Preserved {} untranslated source component(s)", len(preserved_uuids))
+        baseline = self._build_baseline(edges, target_system)
 
-        self._preserve_source_supplemental_attributes(target_system, preserved_uuids)
+        return HopRecord(
+            r2x_core_version=coerce_version(get_package_version("r2x_core", fallback="0.0.0")),
+            source_system_uuid=self._source_system.uuid,
+            from_model=self._source_system.name,
+            to_model=target_system.name,
+            snapshot=self._snapshot_source(),
+            edges=edges,
+            baseline=baseline,
+            time_series_manifest=[],
+        )
+
+    def _snapshot_source(self) -> SystemSnapshot:
+        """Serialize the source system into the infrasys record form.
+
+        Uses ``model_dump_custom()`` (the exact form the system JSON emits,
+        carrying the ``__metadata__`` type discriminator) so a reverse pass
+        reconstructs through the same deserialization path ``from_json`` uses.
+        """
+        components = [
+            component.model_dump_custom() for component in self._source_system.iter_all_components()
+        ]
+        supplemental_attributes = [
+            sa.model_dump_custom()
+            for sa in self._source_system.get_supplemental_attributes(SupplementalAttribute)
+            if not isinstance(sa, SourceProvenance)
+        ]
+        return SystemSnapshot(
+            components=components,
+            supplemental_attributes=supplemental_attributes,
+        )
+
+    def _build_baseline(self, edges: list[HopEdge], target_system: System) -> dict[UUID, dict[str, Any]]:
+        """Capture as-produced values of rule-mapped fields off constructed targets.
+
+        Read after the whole hop has run and validated, so the values reflect
+        pydantic coercion (and any later ``system="target"`` enrichment), not
+        the raw kwargs that entered construction. Scoped to the fields the rule
+        actually produced (recorded per target in ``record_edge``), so a
+        reverse pass compares only rule-produced fields when telling a user
+        edit from a lossy forward transform.
+        """
+        baseline: dict[UUID, dict[str, Any]] = {}
+        target_uuids = {c.uuid for c in target_system.iter_all_components()}
+        for edge in edges:
+            for target_uuid in edge.target_uuids:
+                mapped_fields = self._mapped_fields_by_target.get(target_uuid)
+                # Skip targets with no recorded mapped fields (e.g. SA targets,
+                # which are not components and carry no baseline).
+                if not mapped_fields or target_uuid not in target_uuids:
+                    continue
+                target = target_system.get_component_by_uuid(target_uuid)
+                dumped = target.model_dump(mode="json")
+                baseline[target_uuid] = {field: dumped[field] for field in mapped_fields if field in dumped}
+        return baseline
 
     def finalize(self) -> ProvenanceInfo:
         """Return system-level provenance metadata for the target system.
@@ -263,49 +295,7 @@ class ProvenanceBuilder:
         # deliberately-old marker that a downstream compat check will flag as
         # "produced by an ancient version" rather than silently accept.
         return ProvenanceInfo(
-            r2x_core_version=_coerce_version(get_package_version("r2x_core", fallback="0.0.0")),
+            r2x_core_version=coerce_version(get_package_version("r2x_core", fallback="0.0.0")),
             source_system_uuid=self._source_system.uuid,
             source_system_name=self._source_system.name,
         )
-
-    def _iter_untranslated_source_components(self) -> Iterator[Component]:
-        """Yield source components no rule consumed during translation."""
-        for component in self._source_system.iter_all_components():
-            if component.uuid not in self._translated_source_uuids:
-                yield component
-
-    def _preserve_source_supplemental_attributes(
-        self, target_system: System, preserved_uuids: set[UUID]
-    ) -> None:
-        """Copy source SAs touching preserved components into the target.
-
-        For each source SA:
-
-        - Find its source-side owner components.
-        - Keep only owners whose UUIDs are in ``preserved_uuids`` (i.e. owners
-          that were preserved, not translated). Translated owners already
-          received rule-driven SAs on the target and don't get the source SA
-          re-attached.
-        - If at least one preserved owner remains, deepcopy the SA into the
-          target and attach it to each preserved owner (which exists there
-          under its source UUID).
-        """
-        if not preserved_uuids:
-            return
-
-        # get_supplemental_attributes() with no type arg yields nothing (infrasys
-        # iterates only requested types); pass the base to iterate all subtypes.
-        for source_sa in self._source_system.get_supplemental_attributes(SupplementalAttribute):
-            if isinstance(source_sa, SourceProvenance):
-                # Never carry provenance tags across systems; each translation
-                # produces its own provenance for the target.
-                continue
-            source_owners = self._source_system.get_components_with_supplemental_attribute(source_sa)
-            preserved_owner_uuids = [owner.uuid for owner in source_owners if owner.uuid in preserved_uuids]
-            if not preserved_owner_uuids:
-                continue
-
-            sa_copy = source_sa.model_copy(deep=True)
-            for owner_uuid in preserved_owner_uuids:
-                target_owner = target_system.get_component_by_uuid(owner_uuid)
-                target_system.add_supplemental_attribute(target_owner, sa_copy)

--- a/src/r2x_core/rules.py
+++ b/src/r2x_core/rules.py
@@ -136,6 +136,25 @@ class Rule:
     system: Literal["source", "target"] = "source"
     name: str | None = None
     depends_on: list[str] | None = None
+    consumes: RuleGetter | str | None = field(default=None)
+    """Declares extra source components this rule folds in beyond the iterated one.
+
+    Most rules leave this ``None``: their correspondence is fully derivable
+    from ``source_type``/``target_type`` and the components the executor feeds
+    in and produces. Aggregation rules (many-to-one) do work the executor's
+    per-component loop cannot see (a getter reaching into the system, or a
+    ``system="target"`` rule), so they must *declare* what they consume.
+
+    Given the component the executor iterated, ``consumes`` returns the
+    additional source components this rule folded into the same target. The
+    parameter is the iterated component (which is a source component for
+    ``system="source"`` rules and a target component for ``system="target"``
+    rules), so the same hook covers both directions. Provenance then records
+    ``source_uuids = [iterated, *consumed]`` on one edge.
+
+    Accepts a callable ``(iterated, *, context) -> list[Component]`` or a
+    string naming a registered getter, resolved the same way ``getters`` are.
+    """
 
     def __str__(self) -> str:
         """Represent string."""
@@ -155,6 +174,16 @@ class Rule:
                 raise ValueError(msg)
         if self.filter is not None and not isinstance(self.filter, RuleFilter):
             raise TypeError(f"Rule.filter must be a RuleFilter, not {type(self.filter).__name__}")
+
+        if self.consumes is not None and not callable(self.consumes):
+            if not isinstance(self.consumes, str):
+                raise TypeError(
+                    f"Rule.consumes must be callable or a getter name str, not {type(self.consumes).__name__}"
+                )
+            from .getters import resolve_getter
+
+            resolved = resolve_getter(self.consumes).unwrap_or_raise()
+            object.__setattr__(self, "consumes", resolved)
 
     def __hash__(self) -> int:
         """Hash based on rule's unique identifier."""

--- a/src/r2x_core/rules_executor.py
+++ b/src/r2x_core/rules_executor.py
@@ -85,12 +85,12 @@ def apply_rules_to_context(context: PluginContext) -> TranslationResult:
                 )
                 failed_rules += 1
 
-    if builder is not None and context.target_system is not None:
-        builder.preserve_untranslated(context.target_system)
-
     ts_result = transfer_time_series_metadata(context)
 
     if builder is not None and context.target_system is not None:
+        # Build the hop record after time-series transfer so the mapped-field
+        # baseline reads final, validated target values.
+        context.target_system.translation_history.append(builder.build_hop_record(context.target_system))
         context.target_system.source_provenance_info = builder.finalize()
 
     return TranslationResult(
@@ -153,15 +153,38 @@ def apply_single_rule(
         resolved_targets.append(resolved_class)
 
     found_component = False
+    # Only source-driven rules record correspondence automatically. A
+    # target-driven (system="target") rule iterates the target system, so its
+    # iterated components are not source components; recording them here would
+    # pollute the source-side edge set. Such rules must declare their
+    # correspondence explicitly via builder.record_edge (the imperative path).
+    record_provenance = builder is not None and rule.system == "source"
 
     for src_component in iter_components(read_system, class_type=source_class):
         if rule.filter is not None:
             try:
                 if not evaluate_rule_filter(src_component, rule_filter=rule.filter, context=context):
+                    # The rule named this component's type but its filter
+                    # excluded it: a rule-asserted drop, not "no rule ever
+                    # named it" (which would be unclaimed).
+                    if record_provenance:
+                        assert builder is not None
+                        builder.record_edge(
+                            sources=[src_component],
+                            targets=[],
+                            status="dropped",
+                            rule_name=rule.name,
+                            rule_version=rule.version,
+                        )
                     continue
             except ValueError as exc:
                 return Err(ValueError(f"Failed to evaluate filter for {src_component.label}: {exc}"))
         found_component = True
+
+        # Accumulate every target produced from this one iterated component so
+        # the whole fan-out becomes a single correspondence edge (one source,
+        # many targets) instead of one edge per target.
+        produced_targets: list[Any] = []
         for target_class in resolved_targets:
             fields_result = build_target_fields(src_component, rule=rule, context=context).map_err(
                 lambda e: ValueError(f"Failed to build fields for {src_component.label}: {e}")  # noqa: B023
@@ -189,16 +212,56 @@ def apply_single_rule(
                     src_component.label,
                 )
 
-            if builder is not None and rule.system == "source" and context.target_system is not None:
+            if record_provenance and context.target_system is not None:
+                assert builder is not None
                 builder.record_translation(src_component, component, context.target_system)
 
+            produced_targets.append(component)
             converted += 1
+
+        if record_provenance:
+            assert builder is not None
+            consumed_result = _resolve_consumed_sources(rule, src_component, context=context)
+            if consumed_result.is_err():
+                return consumed_result.map(lambda _: RuleApplicationStats(converted=0, skipped=0))
+            consumed = cast(list[Any], consumed_result.ok())
+            builder.record_edge(
+                sources=[src_component, *consumed],
+                targets=produced_targets,
+                status="translated" if produced_targets else "dropped",
+                rule_name=rule.name,
+                rule_version=rule.version,
+                mapped_fields=set(rule.field_map) | set(rule.getters),
+            )
 
     if not found_component:
         logger.warning("No components found for source type '{}' in rule {}", rule.get_source_types(), rule)
 
     logger.debug("Rule {}: {} converted", rule, converted)
     return Ok(RuleApplicationStats(converted=converted, skipped=0))
+
+
+def _resolve_consumed_sources(
+    rule: Rule, iterated_component: Any, *, context: PluginContext
+) -> Result[list[Any], ValueError]:
+    """Return the extra source components a rule's ``consumes`` hook folds in.
+
+    Returns an empty list when the rule declares no ``consumes``. The hook is
+    called with the iterated component (source for ``system="source"`` rules,
+    target for ``system="target"`` rules), matching the getter calling
+    convention.
+    """
+    if rule.consumes is None:
+        return Ok([])
+    if not callable(rule.consumes):
+        return Err(ValueError(f"Rule.consumes for {rule} is not callable"))
+    try:
+        consumed = rule.consumes(iterated_component, context=context)
+    except Exception as exc:
+        return Err(ValueError(f"consumes hook for {rule} failed: {exc}"))
+    if not isinstance(consumed, list):
+        return Err(ValueError(f"consumes hook for {rule} must return a list, got {type(consumed).__name__}"))
+    return Ok(consumed)
 
 
 def _build_provenance_builder(context: PluginContext) -> ProvenanceBuilder | None:

--- a/src/r2x_core/system.py
+++ b/src/r2x_core/system.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from . import units
 from .provenance import ProvenanceInfo, SourceProvenance
+from .translation_history import HopRecord
 from .utils import (
     filter_kwargs_by_signatures,
     get_package_version,
@@ -93,6 +94,17 @@ class System(InfrasysSystem):
         # SourceProvenance supplemental attributes on the components themselves.
         self.source_provenance_info: ProvenanceInfo | None = None
 
+        # Append-only stack of translation hops (the lens complement). Populated
+        # by the rules executor when PluginContext.preserve_source is True.
+        # Empty otherwise, in which case serialization output is unchanged.
+        self.translation_history: list[HopRecord] = []
+        # Raw hop-record payloads that failed to validate on load (schema newer
+        # than this library, or corrupt), each with its original stack position.
+        # Kept inert so the system still loads (C4: downstream tools must open
+        # the file) and so re-serialization restores the exact original order
+        # (the stack is an append-only chain history; reordering corrupts it).
+        self._unparsed_translation_history: list[tuple[int, dict[str, Any]]] = []
+
         # Define the system base for pint unit conversion.
         # This allows components to convert: device_pu.to('system_base')
         units.ureg.define(f"system_base = {system_base} * MVA")  # overwrite
@@ -128,9 +140,9 @@ class System(InfrasysSystem):
         """Iterate components tagged as rule-produced translations.
 
         If this system contains any :class:`SourceProvenance` tags, this yields
-        only components carrying ``SourceProvenance(preserved=False)``. Untagged
-        components in a provenance-bearing system are neither translated nor
-        preserved; they may be pre-existing target content.
+        only components carrying one. Untagged components in a provenance-bearing
+        system are not rule-produced translations; they may be pre-existing
+        target content.
 
         If no components in this system carry provenance tags, this yields
         every component (i.e. systems that were not built with
@@ -142,9 +154,8 @@ class System(InfrasysSystem):
             Every component tagged as a rule-produced translation, or every
             component when no provenance tags exist.
         """
-        translated = self._provenance_component_uuids(preserved=False)
-        preserved = self._provenance_component_uuids(preserved=True)
-        if not translated and not preserved:
+        translated = self._translated_component_uuids()
+        if not translated:
             yield from self.iter_all_components()
             return
 
@@ -152,56 +163,17 @@ class System(InfrasysSystem):
             if component.uuid in translated:
                 yield component
 
-    def iter_preserved_components(self) -> Iterator[Component]:
-        """Iterate components that were carried over from source without translation.
-
-        Yields
-        ------
-        Component
-            Every component tagged with ``SourceProvenance(preserved=True)``.
-        """
-        preserved = self._provenance_component_uuids(preserved=True)
-        for component in self.iter_all_components():
-            if component.uuid in preserved:
-                yield component
-
-    def is_preserved(self, component: Component) -> bool:
-        """Return True if ``component`` was carried over from source untranslated.
-
-        Cheap single-component check that hits the SA association table
-        directly. When walking many components, prefer
-        :meth:`iter_preserved_components` or :meth:`iter_translated_components`
-        which resolve the whole preserved-UUID set once instead of
-        per-component.
-
-        Parameters
-        ----------
-        component : Component
-            Component to check.
-
-        Returns
-        -------
-        bool
-            True when the component carries ``SourceProvenance(preserved=True)``.
-        """
-        provenance = self.get_supplemental_attributes_with_component(
-            component, supplemental_attribute_type=SourceProvenance
-        )
-        return any(tag.preserved for tag in provenance)
-
-    def _provenance_component_uuids(self, *, preserved: bool) -> set[UUID]:
-        """Return component UUIDs carrying provenance tags matching ``preserved``.
+    def _translated_component_uuids(self) -> set[UUID]:
+        """Return component UUIDs carrying a :class:`SourceProvenance` tag.
 
         Two sqlite scans (one to iterate all ``SourceProvenance`` SAs, one
-        association-table lookup per matching SA) instead of one per
-        component. For a system with N components and K matching provenance
-        SAs, this is ``1 + K`` queries versus ``N`` for the naive
-        per-component approach; K is typically much smaller than N.
+        association-table lookup per SA) instead of one per component. For a
+        system with N components and K provenance SAs, this is ``1 + K``
+        queries versus ``N`` for the naive per-component approach; K is
+        typically much smaller than N.
         """
         result: set[UUID] = set()
         for tag in self.get_supplemental_attributes(SourceProvenance):
-            if tag.preserved != preserved:
-                continue
             for owner in self.get_components_with_supplemental_attribute(tag):
                 result.add(owner.uuid)
         return result
@@ -392,7 +364,9 @@ class System(InfrasysSystem):
         -------
         dict[str, Any]
             Dictionary containing ``system_base_power``, ``r2x_core_version``,
-            and ``source_provenance_info`` when set.
+            ``source_provenance_info`` when set, and ``translation_history``
+            when non-empty. When no provenance was captured, output is
+            identical to a plain system: no extra keys are emitted.
         """
         attrs: dict[str, Any] = {
             "system_base_power": self.base_power,
@@ -400,7 +374,31 @@ class System(InfrasysSystem):
         }
         if self.source_provenance_info is not None:
             attrs["source_provenance_info"] = self.source_provenance_info.model_dump(mode="json")
+        history = self._serialize_translation_history()
+        if history:
+            attrs["translation_history"] = history
         return attrs
+
+    def _serialize_translation_history(self) -> list[dict[str, Any]]:
+        """Serialize the hop stack, restoring unparsed records to their positions.
+
+        Parsed records are dumped in order; unparsed records (retained from a
+        load under schema skew) are spliced back at their original indices so a
+        round trip preserves the exact append-only order.
+        """
+        parsed = [record.model_dump(mode="json") for record in self.translation_history]
+        if not self._unparsed_translation_history:
+            return parsed
+        total = len(parsed) + len(self._unparsed_translation_history)
+        unparsed_by_index = dict(self._unparsed_translation_history)
+        result: list[dict[str, Any]] = []
+        parsed_iter = iter(parsed)
+        for index in range(total):
+            if index in unparsed_by_index:
+                result.append(unparsed_by_index[index])
+            else:
+                result.append(next(parsed_iter))
+        return result
 
     def deserialize_system_attributes(self, data: dict[str, Any]) -> None:
         """Deserialize R2X-specific system attributes.
@@ -426,3 +424,41 @@ class System(InfrasysSystem):
                 warn_if_persisted_version_newer_than_installed(
                     self.source_provenance_info.r2x_core_version, package_name="r2x_core"
                 )
+
+        self._deserialize_translation_history(data.get("translation_history"))
+
+    def _deserialize_translation_history(self, raw_history: Any) -> None:
+        """Load the translation-history stack leniently.
+
+        Records that validate become :class:`HopRecord` instances. Records that
+        do not (a newer schema than this library, or corruption) are retained
+        as raw payloads in ``_unparsed_translation_history`` so they survive a
+        round trip and so the system still loads. Code that relies on the
+        history for recovery must fail loudly on unparsed records rather than
+        silently proceed with a truncated stack.
+        """
+        self.translation_history = []
+        self._unparsed_translation_history = []
+        if not raw_history:
+            return
+        if not isinstance(raw_history, list):
+            logger.warning("Ignoring malformed translation_history: expected a list")
+            return
+        for index, raw_record in enumerate(raw_history):
+            try:
+                self.translation_history.append(HopRecord.model_validate(raw_record))
+            except ValidationError as exc:
+                logger.warning(
+                    "Retaining unparsable translation-history record inertly (schema drift?): {}", exc
+                )
+                self._unparsed_translation_history.append((index, raw_record))
+
+    def has_unparsed_translation_history(self) -> bool:
+        """Return True if any hop record on this system failed to validate on load.
+
+        A reverse/recovery pass must check this and refuse to proceed when True:
+        a record we could not parse may be exactly the one holding the data
+        needed to reconstruct an ancestor, and silently ignoring it would
+        convert losslessness into silent loss.
+        """
+        return bool(self._unparsed_translation_history)

--- a/src/r2x_core/translation_history.py
+++ b/src/r2x_core/translation_history.py
@@ -1,0 +1,192 @@
+"""The translation history: the lens complement for lossless round-trips.
+
+A translation from model X to model Y is lossy (see
+:doc:`../explanations/lossless-translation`). To make the round trip X->Y->X
+recoverable, each hop run with ``PluginContext.preserve_source=True`` appends a
+self-contained :class:`HopRecord` to ``System.translation_history``. The stack
+is append-only: no hop ever mutates or forgets a prior record, so an arbitrary
+chain ``X -> Y -> X -> Z -> Y`` never destroys information a later hop needs.
+
+The complement is the *whole source* (a full snapshot per hop), so GetPut for
+an unedited round-trip is identity by construction, with no residue accounting
+to get wrong. This is forced by two facts: getters are opaque callables (we
+cannot compute which source fields they consumed), and the record must be
+self-contained to survive a cross-tool JSON handoff.
+
+Layout::
+
+    System (active model, pristine)
+      translation_history: list[HopRecord]      # serialized in system JSON
+        HopRecord
+          from_model / to_model / versions / source_system_uuid
+          snapshot: SystemSnapshot              # full source image (infrasys form)
+          edges: list[HopEdge]                  # correspondence, arity as data
+          baseline: {target_uuid: {field: value}}   # as-produced mapped values
+          time_series_manifest: [...]           # array files the snapshot relies on
+
+Everything a reverse ("put") pass needs is a query over this data; the reverse
+pass itself is intentionally *not* implemented here. This module is capture and
+persistence only.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
+from .utils import VersionField
+
+# Bump when the serialized shape of HopRecord/HopEdge/SystemSnapshot changes in
+# a way older readers cannot understand. This is deliberately separate from the
+# r2x_core library version: a component's schema can drift (a renamed field)
+# without the library version telling us anything, and the library version can
+# bump without the on-disk format changing at all.
+TRANSLATION_HISTORY_SCHEMA_VERSION = 1
+
+
+EdgeStatus = Literal["translated", "dropped", "unclaimed"]
+"""Why a source appears (or does not) in the target.
+
+- ``translated``: at least one target component was produced from the source(s).
+- ``dropped``: a rule matched the source but deliberately produced nothing
+  (a rule-asserted intent, e.g. a filter excluded it).
+- ``unclaimed``: no rule ever named the source's type. The executor discovers
+  this after all rules run; it is distinct from ``dropped`` because a
+  reverse-pass policy may treat "nobody claimed this" more conservatively than
+  "a rule chose to drop this" (see the known-risks discussion in the design).
+"""
+
+
+class HopEdge(BaseModel):
+    """One correspondence between source and target components in a hop.
+
+    Arity is data on the edge, not a shape of the type: ``source_uuids`` has
+    more than one entry for many-to-one aggregation, ``target_uuids`` has more
+    than one for one-to-many fan-out, and both may be plural for many-to-many.
+    ``target_uuids`` is empty when ``status`` is ``dropped`` or ``unclaimed``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_uuids: Annotated[
+        list[UUID], Field(description="UUIDs of the source components this edge consumed")
+    ]
+    target_uuids: Annotated[
+        list[UUID],
+        Field(default_factory=list, description="UUIDs of the target components this edge produced"),
+    ]
+    rule_name: Annotated[
+        str | None, Field(default=None, description="Name of the rule that produced this edge, if named")
+    ] = None
+    rule_version: Annotated[
+        int | None,
+        Field(default=None, description="Version of the rule that produced this edge, if a rule ran"),
+    ] = None
+    status: Annotated[EdgeStatus, Field(description="Why the source(s) appear or do not in the target")]
+
+    @field_serializer("source_uuids", "target_uuids")
+    def _serialize_uuid_list(self, value: list[UUID]) -> list[str]:
+        """Render UUID lists as canonical strings for JSON output."""
+        return [str(item) for item in value]
+
+
+class SystemSnapshot(BaseModel):
+    """A full, self-contained image of a source system in infrasys form.
+
+    ``components`` and ``supplemental_attributes`` are the exact records the
+    infrasys system JSON emits (``model_dump_custom()`` output, carrying the
+    ``__metadata__`` type discriminator), so a reverse pass reconstructs them
+    through the same deserialization path :meth:`System.from_json` uses. This
+    is why the snapshot survives ``extra="forbid"`` models with computed-field
+    discriminators: it never round-trips through a plain ``model_validate``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    components: Annotated[
+        list[dict[str, Any]],
+        Field(description="Source components as infrasys serialization records (with __metadata__)"),
+    ]
+    supplemental_attributes: Annotated[
+        list[dict[str, Any]],
+        Field(
+            default_factory=list,
+            description="Source supplemental attributes as infrasys serialization records",
+        ),
+    ]
+
+
+class HopRecord(BaseModel):
+    """One translation hop: the source image plus the correspondence it produced.
+
+    Self-contained by construction (full snapshot, no external references), so
+    it survives a cross-tool JSON handoff and lets a later reverse pass
+    reconstruct the source without the original system on disk.
+    """
+
+    # extra="forbid" (not "allow") on purpose: an unknown field means the record
+    # came from a newer schema this library does not understand. We want that to
+    # raise so the loader can retain the raw payload inertly with full fidelity,
+    # rather than silently parsing a partial view and dropping the unknown
+    # fields on the next dump.
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
+
+    schema_version: Annotated[
+        int,
+        Field(
+            default=TRANSLATION_HISTORY_SCHEMA_VERSION,
+            description="Serialized-format version of this hop record",
+            le=TRANSLATION_HISTORY_SCHEMA_VERSION,
+        ),
+    ] = TRANSLATION_HISTORY_SCHEMA_VERSION
+    r2x_core_version: Annotated[VersionField, Field(description="r2x-core version that produced this hop")]
+    source_system_uuid: Annotated[UUID, Field(description="UUID of the source system for this hop")]
+    from_model: Annotated[
+        str | None, Field(default=None, description="Name of the model translated from, if known")
+    ] = None
+    to_model: Annotated[
+        str | None, Field(default=None, description="Name of the model translated to, if known")
+    ] = None
+    snapshot: Annotated[SystemSnapshot, Field(description="Full image of the source system")]
+    edges: Annotated[
+        list[HopEdge], Field(default_factory=list, description="Source-to-target correspondence edges")
+    ]
+    baseline: Annotated[
+        dict[UUID, dict[str, Any]],
+        Field(
+            default_factory=dict,
+            description=(
+                "Per target component, the as-produced values of its mapped fields, captured after "
+                "validation. Lets a reverse pass tell a user edit (current != baseline) from a "
+                "lossy forward transform (current == baseline)."
+            ),
+        ),
+    ]
+    time_series_manifest: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description=(
+                "Time-series array file identifiers the snapshot relies on. Lets serialization "
+                "assert every referenced array is present instead of discovering a dangling "
+                "reference at recovery time."
+            ),
+        ),
+    ]
+
+    @field_serializer("r2x_core_version")
+    def _serialize_version(self, value: Any) -> str:
+        """Render the version as its PEP 440 string form for JSON output."""
+        return str(value)
+
+    @field_serializer("source_system_uuid")
+    def _serialize_uuid(self, value: UUID) -> str:
+        """Render the UUID as its canonical string form for JSON output."""
+        return str(value)
+
+    @field_serializer("baseline")
+    def _serialize_baseline(self, value: dict[UUID, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        """Render baseline keys (target UUIDs) as strings for JSON output."""
+        return {str(key): fields for key, fields in value.items()}

--- a/src/r2x_core/utils/__init__.py
+++ b/src/r2x_core/utils/__init__.py
@@ -35,18 +35,26 @@ from .validation import (
     validate_file_extension,
     validate_glob_pattern,
 )
-from .version import UNKNOWN_VERSION, get_package_version, warn_if_persisted_version_newer_than_installed
+from .version import (
+    UNKNOWN_VERSION,
+    VersionField,
+    coerce_version,
+    get_package_version,
+    warn_if_persisted_version_newer_than_installed,
+)
 
 __all__ = [
     "UNKNOWN_VERSION",
     "UpgradeCoordinator",
     "UpgradeStep",
     "UpgradeType",
+    "VersionField",
     "audit_file",
     "backup_folder",
     "build_attr_getter",
     "build_component_kwargs",
     "build_target_fields",
+    "coerce_version",
     "components_to_records",
     "create_component",
     "create_target_component",

--- a/src/r2x_core/utils/version.py
+++ b/src/r2x_core/utils/version.py
@@ -3,11 +3,40 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
+from typing import Annotated, Any
 
 from loguru import logger
 from packaging.version import InvalidVersion, Version
+from pydantic import BeforeValidator
 
 UNKNOWN_VERSION = "unknown"
+
+
+def coerce_version(value: Any) -> Version:
+    """Accept a Version or PEP 440 string; raise a clear error otherwise.
+
+    Parameters
+    ----------
+    value : Any
+        A :class:`packaging.version.Version` or a PEP 440 version string.
+
+    Returns
+    -------
+    Version
+        The coerced version.
+    """
+    if isinstance(value, Version):
+        return value
+    if isinstance(value, str):
+        try:
+            return Version(value)
+        except InvalidVersion as exc:
+            raise ValueError(f"{value!r} is not a valid PEP 440 version") from exc
+    raise TypeError(f"expected str or packaging.version.Version, got {type(value).__name__}")
+
+
+VersionField = Annotated[Version, BeforeValidator(coerce_version)]
+"""A pydantic field type that accepts a Version or PEP 440 string."""
 
 
 def get_package_version(package_name: str, *, fallback: str = UNKNOWN_VERSION) -> str:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -195,3 +195,39 @@ def test_rule_filter_pattern_variants():
 
     with pytest.raises(ValueError):
         RuleFilter(field="value", op="geq", values=[1, 2])
+
+
+def test_rule_consumes_string_resolves_to_callable():
+    """A string consumes reference resolves to a registered getter callable."""
+    from rust_ok import Ok
+
+    from r2x_core import Rule, getter
+
+    @getter(name="_consumes_resolution_probe")
+    def _probe(iterated, *, context):
+        return Ok([])
+
+    rule = Rule(
+        source_type="A",
+        target_type="B",
+        version=1,
+        field_map={"f": "f"},
+        consumes="_consumes_resolution_probe",
+    )
+    assert callable(rule.consumes)
+
+
+def test_rule_consumes_rejects_non_callable_non_string():
+    """consumes must be a callable or a getter-name string."""
+    from r2x_core import Rule
+
+    with pytest.raises(TypeError, match=r"Rule\.consumes must be callable or a getter name str"):
+        Rule(source_type="A", target_type="B", version=1, consumes=123)  # type: ignore[arg-type]
+
+
+def test_rule_consumes_defaults_to_none():
+    """Rules without aggregation leave consumes unset."""
+    from r2x_core import Rule
+
+    rule = Rule(source_type="A", target_type="B", version=1, field_map={"f": "f"})
+    assert rule.consumes is None

--- a/tests/test_source_provenance.py
+++ b/tests/test_source_provenance.py
@@ -2,12 +2,8 @@
 
 Exercises the ``preserve_source`` flag on ``PluginContext``:
 
-- Translated components get tagged with ``SourceProvenance(preserved=False)``
-  carrying the source UUID.
-- Untranslated source components are copied into the target and tagged with
-  ``SourceProvenance(preserved=True)`` while keeping their original UUID.
-- Source supplemental attributes riding on preserved components are carried
-  over and re-attached.
+- Translated components get tagged with a ``SourceProvenance`` carrying the
+  source UUID.
 - ``System.source_provenance_info`` records source-side identity.
 - Everything above survives a JSON round-trip.
 """
@@ -95,100 +91,7 @@ def test_translated_components_get_source_provenance_tag(
         translated[0], supplemental_attribute_type=SourceProvenance
     )
     assert len(tags) == 1
-    assert tags[0].preserved is False
     assert tags[0].source_uuid == source_bus.uuid
-
-
-def test_untranslated_source_component_is_preserved_with_uuid(
-    context_preserve_source: PluginContext,
-) -> None:
-    """A source component with no matching rule shows up in the target under its source UUID."""
-    from infrasys import Component
-    from pydantic import Field
-
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    # A brand-new source type that no fixture rule matches (not a subtype of
-    # anything the rules already handle).
-    class UnmappedSourceType(Component):
-        """Source-only type with no translation rule."""
-
-        payload: str = Field(default="")
-
-    phantom = UnmappedSourceType(name="phantom", payload="data")
-    src.add_component(phantom)
-
-    apply_rules_to_context(context_preserve_source)
-
-    preserved = list(tgt.iter_preserved_components())
-    preserved_uuids = {c.uuid for c in preserved}
-    assert phantom.uuid in preserved_uuids
-
-    carried = next(c for c in preserved if c.uuid == phantom.uuid)
-    tags = tgt.get_supplemental_attributes_with_component(
-        carried, supplemental_attribute_type=SourceProvenance
-    )
-    assert len(tags) == 1
-    assert tags[0].preserved is True
-    assert tags[0].source_uuid == phantom.uuid
-
-
-def test_iter_translated_excludes_preserved(context_preserve_source: PluginContext) -> None:
-    """iter_translated_components yields only rule-produced components; iter_preserved yields carry-overs."""
-    from infrasys import Component
-    from pydantic import Field
-
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    class UnmappedSource(Component):
-        payload: str = Field(default="")
-
-    src.add_component(UnmappedSource(name="drop_me"))
-    apply_rules_to_context(context_preserve_source)
-
-    translated_uuids = {c.uuid for c in tgt.iter_translated_components()}
-    preserved_uuids = {c.uuid for c in tgt.iter_preserved_components()}
-    all_uuids = {c.uuid for c in tgt.iter_all_components()}
-    untagged_uuids = all_uuids - translated_uuids - preserved_uuids
-
-    assert translated_uuids.isdisjoint(preserved_uuids)
-    assert untagged_uuids, "pre-seeded target fixture components are intentionally untagged"
-    assert translated_uuids | preserved_uuids | untagged_uuids == all_uuids
-
-
-def test_preserved_supplemental_attributes_are_carried_over(
-    context_preserve_source: PluginContext,
-) -> None:
-    """Source SAs attached to untranslated components ride into the target and re-attach."""
-    from fixtures.source_system import BusGeographicInfo
-    from infrasys import Component
-    from pydantic import Field
-
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    class UnmappedType(Component):
-        payload: str = Field(default="")
-
-    unmapped = UnmappedType(name="preserved_thing", payload="x")
-    src.add_component(unmapped)
-    geo = BusGeographicInfo(latitude=40.7, longitude=-74.0, location_name="somewhere")
-    src.add_supplemental_attribute(unmapped, geo)
-
-    apply_rules_to_context(context_preserve_source)
-
-    carried = next(c for c in tgt.iter_preserved_components() if c.uuid == unmapped.uuid)
-    carried_sas = tgt.get_supplemental_attributes_with_component(
-        carried, supplemental_attribute_type=BusGeographicInfo
-    )
-    assert len(carried_sas) == 1
-    assert carried_sas[0].location_name == "somewhere"
-    assert carried_sas[0].latitude == pytest.approx(40.7)
 
 
 def test_preserve_source_off_produces_no_provenance(
@@ -212,7 +115,6 @@ def test_preserve_source_off_produces_no_provenance(
     assert ctx.target_system.source_provenance_info is None
     tags = list(ctx.target_system.get_supplemental_attributes(SourceProvenance))
     assert tags == []
-    assert list(ctx.target_system.iter_preserved_components()) == []
     assert {c.uuid for c in ctx.target_system.iter_translated_components()} == {
         c.uuid for c in ctx.target_system.iter_all_components()
     }
@@ -231,10 +133,7 @@ def test_provenance_survives_json_round_trip(context_preserve_source: PluginCont
 
     apply_rules_to_context(context_preserve_source)
 
-    original_source_uuids = {
-        unmapped.uuid,
-        *{tag.source_uuid for tag in tgt.get_supplemental_attributes(SourceProvenance)},
-    }
+    original_source_uuids = {tag.source_uuid for tag in tgt.get_supplemental_attributes(SourceProvenance)}
 
     with tempfile.TemporaryDirectory() as td:
         path = Path(td) / "sys.json"
@@ -244,9 +143,7 @@ def test_provenance_survives_json_round_trip(context_preserve_source: PluginCont
     assert loaded.source_provenance_info is not None
     assert loaded.source_provenance_info.source_system_uuid == src.uuid
 
-    loaded_source_uuids = {c.uuid for c in loaded.iter_preserved_components()} | {
-        tag.source_uuid for tag in loaded.get_supplemental_attributes(SourceProvenance)
-    }
+    loaded_source_uuids = {tag.source_uuid for tag in loaded.get_supplemental_attributes(SourceProvenance)}
     assert loaded_source_uuids == original_source_uuids
 
     loaded_nodes = list(loaded.get_components(NodeComponent))
@@ -262,24 +159,6 @@ def test_provenance_survives_json_round_trip(context_preserve_source: PluginCont
             node, supplemental_attribute_type=SourceProvenance
         )
         assert len(tags) == 1
-        assert tags[0].preserved is False
-
-
-def test_is_preserved_public_wrapper(context_preserve_source: PluginContext) -> None:
-    """System.is_preserved returns True for carry-overs, False for translations."""
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-    unmapped = RoundTripUnmappedType(name="is_preserved_probe", payload="y")
-    src.add_component(unmapped)
-
-    apply_rules_to_context(context_preserve_source)
-
-    preserved = next(c for c in tgt.iter_preserved_components() if c.uuid == unmapped.uuid)
-    assert tgt.is_preserved(preserved) is True
-
-    translated = next(iter(tgt.iter_translated_components()))
-    assert tgt.is_preserved(translated) is False
 
 
 def test_malformed_provenance_info_ignored_not_fatal(
@@ -361,129 +240,30 @@ def test_provenance_info_rejects_wrong_version_type() -> None:
         )
 
 
-def test_supplemental_attribute_with_no_preserved_owners_is_skipped(
-    context_preserve_source: PluginContext,
-) -> None:
-    """SAs whose every owner was translated do not ride into the target."""
-    from fixtures.source_system import BusComponent, BusGeographicInfo
+def test_record_edge_requires_at_least_one_source(source_system: System) -> None:
+    """record_edge rejects an empty source list: an edge with no source is meaningless."""
+    from r2x_core.provenance import ProvenanceBuilder
 
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    # Attach an SA to a bus that WILL be translated (rules_simple maps BusComponent).
-    # That means the SA's only owner is translated, so preserve_untranslated should skip it.
-    translated_bus = next(src.get_components(BusComponent))
-    only_translated_sa = BusGeographicInfo(latitude=1.0, longitude=2.0, location_name="only_on_translated")
-    src.add_supplemental_attribute(translated_bus, only_translated_sa)
-
-    # Force at least one preserved component so the SA loop actually runs.
-    src.add_component(RoundTripUnmappedType(name="forces_sa_loop", payload="x"))
-
-    apply_rules_to_context(context_preserve_source)
-
-    carried_geo = list(tgt.get_supplemental_attributes(BusGeographicInfo))
-    # Only the SAs attached to preserved components should appear; the translated-only one is filtered out.
-    for sa in carried_geo:
-        assert sa.location_name != "only_on_translated"
+    builder = ProvenanceBuilder(source_system)
+    with pytest.raises(ValueError, match="record_edge requires at least one source"):
+        builder.record_edge(sources=[], targets=[], status="dropped")
 
 
-def test_record_translation_with_sa_target_does_not_consume_source(
-    source_system: System,
-) -> None:
-    """An SA-target ``record_translation`` leaves the source available for preservation.
+def test_record_translation_sa_target_is_noop(source_system: System) -> None:
+    """record_translation does nothing for a supplemental-attribute target.
 
-    If a rule produces an SA (not a Component) from a source, the source has
-    no target-side Component representation. Marking it as translated would
-    lose it from a reverse trip. So SA targets are recorded as "no-op on the
-    translated set" and the source flows through preservation.
+    SAs cannot own SAs, so no SourceProvenance tag is attached; the
+    correspondence is captured in the hop record instead.
     """
     from fixtures.source_system import BusComponent, BusGeographicInfo
 
-    from r2x_core.provenance import ProvenanceBuilder
+    from r2x_core.provenance import ProvenanceBuilder, SourceProvenance
 
     tgt = System(system_base=100.0, name="target")
     builder = ProvenanceBuilder(source_system)
     src_bus = next(source_system.get_components(BusComponent))
-    sa_target = BusGeographicInfo(latitude=1.0, longitude=2.0, location_name="test")
+    sa_target = BusGeographicInfo(latitude=1.0, longitude=2.0, location_name="x")
 
-    # No SourceProvenance is attached to sa_target (SAs cannot own SAs), AND
-    # the source is NOT marked translated because no Component was produced.
+    # Must not raise and must not attach any tag.
     builder.record_translation(src_bus, sa_target, tgt)
-
-    builder.preserve_untranslated(tgt)
-    preserved_uuids = {c.uuid for c in tgt.iter_preserved_components()}
-    assert src_bus.uuid in preserved_uuids
-
-
-def test_preserve_untranslated_no_op_when_everything_translated(
-    context_preserve_source: PluginContext,
-) -> None:
-    """When every source component has a rule, no carry-overs are produced and the SA loop is skipped."""
-    from r2x_core.provenance import ProvenanceBuilder
-
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    # Mark every source component as translated by feeding record_translation
-    # a synthetic target component per source. We reuse the source components
-    # themselves as the "target" argument since we only care about the uuid
-    # bookkeeping side of the call, and the SA branch short-circuits attach.
-    builder = ProvenanceBuilder(src)
-    scratch_target = System(system_base=100.0, name="scratch")
-    for comp in src.iter_all_components():
-        clone = src.deepcopy_component(comp)
-        scratch_target.add_component(clone)
-        builder.record_translation(comp, clone, scratch_target)
-
-    builder.preserve_untranslated(tgt)
-    assert list(tgt.iter_preserved_components()) == []
-
-
-def test_source_provenance_tags_are_not_carried_across(
-    context_preserve_source: PluginContext,
-) -> None:
-    """SourceProvenance SAs on the source system are not re-copied to the target."""
-
-    src = context_preserve_source.source_system
-    tgt = context_preserve_source.target_system
-    assert src is not None and tgt is not None
-
-    # Pre-tag a source component with a SourceProvenance (simulating a system
-    # that already went through a translation earlier).
-    unmapped = RoundTripUnmappedType(name="already_tagged", payload="x")
-    src.add_component(unmapped)
-    stray_tag = SourceProvenance(source_uuid=unmapped.uuid, preserved=True)
-    src.add_supplemental_attribute(unmapped, stray_tag)
-
-    apply_rules_to_context(context_preserve_source)
-
-    carried = next(c for c in tgt.iter_preserved_components() if c.uuid == unmapped.uuid)
-    tags = tgt.get_supplemental_attributes_with_component(
-        carried, supplemental_attribute_type=SourceProvenance
-    )
-    # Exactly one tag: the fresh one this translation produced, not the stray.
-    assert len(tags) == 1
-    assert tags[0].uuid != stray_tag.uuid
-
-
-def test_preserve_untranslated_raises_contextual_error_on_uuid_collision(
-    source_system: System,
-) -> None:
-    """When target already holds a component with a source UUID, the wrapped error explains why."""
-    from fixtures.source_system import BusComponent
-    from infrasys.exceptions import ISAlreadyAttached
-
-    from r2x_core.provenance import ProvenanceBuilder
-
-    # Pre-populate target with a component that has the SAME UUID as a source bus.
-    src_bus = next(source_system.get_components(BusComponent))
-    tgt = System(system_base=100.0, name="target")
-    collision = source_system.deepcopy_component(src_bus)
-    tgt.add_component(collision)
-
-    builder = ProvenanceBuilder(source_system)
-    # No record_translation calls -> every source component is "untranslated".
-    with pytest.raises(ISAlreadyAttached, match=r"Cannot preserve source component"):
-        builder.preserve_untranslated(tgt)
+    assert list(tgt.get_supplemental_attributes(SourceProvenance)) == []

--- a/tests/test_translation_history.py
+++ b/tests/test_translation_history.py
@@ -1,0 +1,579 @@
+"""Tests for the translation-history stack (the lens complement).
+
+Covers the capture-and-persistence half of lossless round-trip translation:
+
+- Serialization output is byte-identical when no history is captured (C6).
+- Hop records survive a JSON round trip, and snapshots reconstruct through the
+  same infrasys path ``from_json`` uses (even under ``extra="forbid"`` with a
+  computed-field discriminator).
+- Records that fail to validate on load are retained inertly, not dropped.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from uuid import uuid4
+
+import orjson
+import pytest
+from infrasys import Component
+from pydantic import ConfigDict, Field, ValidationError, computed_field
+
+from r2x_core import System
+from r2x_core.translation_history import (
+    TRANSLATION_HISTORY_SCHEMA_VERSION,
+    HopEdge,
+    HopRecord,
+    SystemSnapshot,
+)
+
+
+class SnapshotProbe(Component):
+    """Module-level component so infrasys can re-import it on deserialization."""
+
+    payload: str = Field(default="")
+
+
+class ForbidComputedProbe(Component):
+    """Component with a computed-field discriminator under ``extra='forbid'``.
+
+    Mirrors downstream model packages (r2x-sienna) whose ``model_dump()`` emits
+    a ``class_type`` that a naive ``model_validate`` would reject. The snapshot
+    must round-trip through the infrasys serialization form instead.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    payload: str = Field(default="")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def class_type(self) -> str:
+        """Serialization-only discriminator."""
+        return type(self).__name__
+
+
+def _json_body(path: Path) -> dict:
+    """Return the parsed system JSON body (excludes sqlite/arrow sidecars)."""
+    return orjson.loads(path.read_bytes())
+
+
+def _snapshot_of(system: System) -> SystemSnapshot:
+    """Build a SystemSnapshot from a system in the infrasys serialization form."""
+    return SystemSnapshot(
+        components=[c.model_dump_custom() for c in system.iter_all_components()],
+        supplemental_attributes=[],
+    )
+
+
+def _hop_record_for(system: System) -> HopRecord:
+    """Build a minimal valid HopRecord snapshotting ``system``."""
+    return HopRecord(
+        r2x_core_version="1.2.3",
+        source_system_uuid=system.uuid,
+        from_model="X",
+        to_model="Y",
+        snapshot=_snapshot_of(system),
+        edges=[
+            HopEdge(
+                source_uuids=[c.uuid for c in system.iter_all_components()],
+                target_uuids=[],
+                status="unclaimed",
+            )
+        ],
+    )
+
+
+def test_serialization_omits_history_key_when_empty() -> None:
+    """With no history captured, the system JSON carries no ``translation_history``.
+
+    This is the C6 zero-cost-when-off contract: a system that never opted into
+    preservation serializes exactly like a plain system, with no extra keys.
+    Asserted before any history is wired into the executor. (The only field
+    that legitimately varies between dumps is ``time_series.directory``, which
+    is derived from the output filename, not from preservation.)
+    """
+    system = System(system_base=100.0, name="plain")
+    system.add_component(SnapshotProbe(name="a", payload="x"))
+
+    assert system.translation_history == []
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "sys.json"
+        system.to_json(path)
+        body = _json_body(path)
+
+    assert "translation_history" not in body
+    # The serialize hook must not inject any preservation key when off.
+    assert "source_provenance_info" not in body
+
+
+def test_serialization_adds_only_history_key_when_present() -> None:
+    """Capturing history adds exactly the ``translation_history`` key, nothing else.
+
+    Compares the JSON body with and without a captured record (same in-memory
+    system, same output path stem), so the diff isolates precisely what
+    preservation adds: one key, and no mutation of any other field.
+    """
+    system = System(system_base=100.0, name="plain")
+    system.add_component(SnapshotProbe(name="a", payload="x"))
+
+    with tempfile.TemporaryDirectory() as td:
+        off_path = Path(td) / "sys.json"
+        system.to_json(off_path, overwrite=True)
+        off_body = _json_body(off_path)
+
+        system.translation_history.append(_hop_record_for(system))
+        on_path = Path(td) / "sys.json"
+        system.to_json(on_path, overwrite=True)
+        on_body = _json_body(on_path)
+
+    assert set(on_body) - set(off_body) == {"translation_history"}
+    # Every other field is untouched by preservation.
+    for key in off_body:
+        assert on_body[key] == off_body[key], f"preservation mutated unrelated key {key!r}"
+
+
+def test_hop_record_survives_json_round_trip() -> None:
+    """A captured hop record round-trips through to_json / from_json intact."""
+    system = System(system_base=100.0, name="src")
+    probe = SnapshotProbe(name="thing", payload="data")
+    system.add_component(probe)
+
+    system.translation_history.append(_hop_record_for(system))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "sys.json"
+        system.to_json(path)
+        body = _json_body(path)
+        assert "translation_history" in body
+        loaded = System.from_json(path)
+
+    assert len(loaded.translation_history) == 1
+    record = loaded.translation_history[0]
+    assert record.schema_version == TRANSLATION_HISTORY_SCHEMA_VERSION
+    assert record.from_model == "X"
+    assert record.to_model == "Y"
+    assert record.source_system_uuid == system.uuid
+    assert len(record.snapshot.components) == 1
+    assert record.edges[0].status == "unclaimed"
+    assert probe.uuid in record.edges[0].source_uuids
+    assert not loaded.has_unparsed_translation_history()
+
+
+def test_snapshot_reconstructs_component_via_infrasys_path() -> None:
+    """A snapshot record instantiates the original component through infrasys.
+
+    Uses the same first-pass deserialization the system loader uses, so the
+    ``extra="forbid"`` + computed-field case that breaks naive model_validate
+    is handled by construction.
+    """
+    from infrasys.serialization import CachedTypeHelper
+
+    system = System(system_base=100.0, name="src")
+    original = ForbidComputedProbe(name="widget", payload="keepme")
+    system.add_component(original)
+
+    record = _hop_record_for(system)
+    (component_record,) = record.snapshot.components
+
+    # Recovery reconstructs into a *fresh* system (the source no longer exists),
+    # via the same path System.from_json uses internally.
+    restored_system = System(system_base=100.0, name="restored")
+    restored = restored_system._try_deserialize_component(component_record, CachedTypeHelper())
+    assert restored is not None
+    assert restored.uuid == original.uuid
+    assert restored.payload == "keepme"
+
+
+def test_unparsable_record_retained_inertly_not_dropped() -> None:
+    """A hop record too new to validate is kept as raw payload and flagged.
+
+    Losslessness must not silently degrade: the record survives the round trip
+    and ``has_unparsed_translation_history`` reports it so a recovery pass can
+    refuse to proceed.
+    """
+    system = System(system_base=100.0, name="src")
+    system.add_component(SnapshotProbe(name="a"))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "sys.json"
+        system.to_json(path)
+        body = _json_body(path)
+        # Inject a record from a hypothetical future schema the loader cannot parse.
+        body["translation_history"] = [{"schema_version": 9999, "totally": "unknown-shape"}]
+        path.write_bytes(orjson.dumps(body))
+
+        loaded = System.from_json(path)
+
+    assert loaded.translation_history == []
+    assert loaded.has_unparsed_translation_history()
+
+    # The unparsed record must survive re-serialization (no silent data loss).
+    with tempfile.TemporaryDirectory() as td:
+        path2 = Path(td) / "sys2.json"
+        loaded.to_json(path2)
+        body2 = _json_body(path2)
+
+    assert body2["translation_history"] == [{"schema_version": 9999, "totally": "unknown-shape"}]
+
+
+def test_unparsed_records_keep_stack_order_across_round_trip() -> None:
+    """A future-schema record interleaved with valid ones keeps its position.
+
+    The stack is an append-only chain history, so order is significant. An
+    unparsable record spliced back at the wrong index would corrupt the chain.
+    """
+    system = System(system_base=100.0, name="src")
+    system.add_component(SnapshotProbe(name="a"))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "sys.json"
+        system.to_json(path)
+        body = _json_body(path)
+        valid = HopRecord(
+            r2x_core_version="1.0.0",
+            source_system_uuid=system.uuid,
+            snapshot=SystemSnapshot(components=[], supplemental_attributes=[]),
+        ).model_dump(mode="json")
+        future = {"schema_version": 9999, "marker": "future"}
+        # Order: valid, future, valid  -> the future record sits at index 1.
+        valid_b = dict(valid)
+        valid_b["to_model"] = "second"
+        body["translation_history"] = [valid, future, valid_b]
+        path.write_bytes(orjson.dumps(body))
+
+        loaded = System.from_json(path)
+
+    assert loaded.has_unparsed_translation_history()
+    assert len(loaded.translation_history) == 2
+
+    with tempfile.TemporaryDirectory() as td:
+        path2 = Path(td) / "sys2.json"
+        loaded.to_json(path2)
+        history = _json_body(path2)["translation_history"]
+
+    assert len(history) == 3
+    assert history[1] == future, "future-schema record must stay at its original index"
+    assert history[2]["to_model"] == "second"
+
+
+def test_hop_edge_rejects_unknown_fields() -> None:
+    """HopEdge forbids extra fields so schema drift is caught, not swallowed."""
+    with pytest.raises(ValidationError):
+        HopEdge(source_uuids=[uuid4()], status="translated", bogus="nope")  # type: ignore[call-arg]
+
+
+def test_hop_record_rejects_newer_schema_version() -> None:
+    """A record from a newer schema is rejected, so the loader retains it inertly.
+
+    Without this, a structurally-compatible future record would validate, get
+    parsed into a partial view, and lose any fields this library does not know
+    about on the next dump: silent data loss in a losslessness feature.
+    """
+    with pytest.raises(ValidationError):
+        HopRecord(
+            schema_version=TRANSLATION_HISTORY_SCHEMA_VERSION + 1,
+            r2x_core_version="1.0.0",
+            source_system_uuid=uuid4(),
+            snapshot=SystemSnapshot(components=[], supplemental_attributes=[]),
+        )
+
+
+def test_hop_record_rejects_unknown_fields() -> None:
+    """An unknown field means a newer schema; forbid it so it is retained inertly."""
+    with pytest.raises(ValidationError):
+        HopRecord(
+            r2x_core_version="1.0.0",
+            source_system_uuid=uuid4(),
+            snapshot=SystemSnapshot(components=[], supplemental_attributes=[]),
+            future_field="surprise",  # type: ignore[call-arg]
+        )
+
+
+# --- end-to-end capture through the executor ---------------------------------
+
+
+def _preserve_context(rules, source_system, target_system):
+    """Build a preserve_source=True PluginContext for the fixture systems."""
+    from r2x_core import PluginConfig, PluginContext
+
+    return PluginContext(
+        source_system=source_system,
+        target_system=target_system,
+        config=PluginConfig(models=("fixtures.source_system", "fixtures.target_system")),
+        rules=rules,
+        preserve_source=True,
+    )
+
+
+def test_executor_appends_one_hop_record(rules_simple, source_system, target_system) -> None:
+    """A preserve_source translation appends exactly one hop record to the target."""
+    from r2x_core import apply_rules_to_context
+
+    ctx = _preserve_context(rules_simple, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    assert ctx.target_system is not None
+    assert len(ctx.target_system.translation_history) == 1
+    record = ctx.target_system.translation_history[0]
+    assert record.source_system_uuid == source_system.uuid
+    assert record.from_model == source_system.name
+    assert record.to_model == target_system.name
+    # The snapshot holds every source component.
+    assert len(record.snapshot.components) == len(list(source_system.iter_all_components()))
+
+
+def test_executor_records_one_to_one_edges_with_baseline(rules_simple, source_system, target_system) -> None:
+    """1:1 rules produce translated edges with single source/target and a baseline."""
+    from fixtures.source_system import BusComponent
+
+    from r2x_core import apply_rules_to_context
+
+    src_bus = next(source_system.get_components(BusComponent))
+    ctx = _preserve_context(rules_simple, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    record = ctx.target_system.translation_history[0]
+    bus_edges = [e for e in record.edges if src_bus.uuid in e.source_uuids]
+    assert len(bus_edges) == 1
+    edge = bus_edges[0]
+    assert edge.status == "translated"
+    assert len(edge.source_uuids) == 1
+    assert len(edge.target_uuids) == 1
+    # Baseline captured off the constructed target, post-validation.
+    (target_uuid,) = edge.target_uuids
+    assert target_uuid in record.baseline
+    assert record.baseline[target_uuid]["name"] == src_bus.name
+
+
+def test_executor_marks_unnamed_source_type_unclaimed(rules_simple, source_system, target_system) -> None:
+    """A source component whose type no rule names is recorded as ``unclaimed``."""
+    from r2x_core import apply_rules_to_context
+
+    phantom = SnapshotProbe(name="orphan", payload="z")
+    source_system.add_component(phantom)
+
+    ctx = _preserve_context(rules_simple, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    record = ctx.target_system.translation_history[0]
+    phantom_edges = [e for e in record.edges if phantom.uuid in e.source_uuids]
+    assert len(phantom_edges) == 1
+    assert phantom_edges[0].status == "unclaimed"
+    assert phantom_edges[0].target_uuids == []
+    # The phantom still rides in the snapshot for later recovery.
+    snapshot_uuids = {c["uuid"] for c in record.snapshot.components}
+    assert str(phantom.uuid) in snapshot_uuids
+
+
+def test_executor_filtered_out_source_is_dropped_not_unclaimed(source_system, target_system) -> None:
+    """A source the rule names but its filter excludes is ``dropped``, not ``unclaimed``.
+
+    The distinction matters for a reverse pass: ``dropped`` is a rule-asserted
+    exclusion, ``unclaimed`` means no rule ever named the type. Conflating them
+    is the silent-misclassification risk the design calls out.
+    """
+    from fixtures.source_system import BusComponent
+
+    from r2x_core import Rule, apply_rules_to_context
+
+    # A rule that names BusComponent but filters to a zone no bus has.
+    rule = Rule.from_records(
+        [
+            {
+                "source_type": "BusComponent",
+                "target_type": "NodeComponent",
+                "version": 1,
+                "field_map": {"name": "name", "uuid": "uuid"},
+                "filter": {"field": "zone", "op": "eq", "values": ["nonexistent-zone"]},
+            }
+        ]
+    )
+    src_bus = next(source_system.get_components(BusComponent))
+
+    ctx = _preserve_context(rule, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    record = ctx.target_system.translation_history[0]
+    bus_edges = [e for e in record.edges if src_bus.uuid in e.source_uuids]
+    assert len(bus_edges) == 1
+    assert bus_edges[0].status == "dropped"
+    assert bus_edges[0].rule_version == 1
+
+
+def test_executor_history_survives_round_trip(rules_simple, source_system, target_system) -> None:
+    """A captured hop record survives to_json / from_json on the translated system."""
+    from r2x_core import apply_rules_to_context
+
+    ctx = _preserve_context(rules_simple, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "translated.json"
+        ctx.target_system.to_json(path)
+        loaded = System.from_json(path)
+
+    assert len(loaded.translation_history) == 1
+    assert loaded.translation_history[0].source_system_uuid == source_system.uuid
+    assert not loaded.has_unparsed_translation_history()
+
+
+def test_consumes_records_aggregated_sources_on_one_edge(source_system, target_system) -> None:
+    """A rule's ``consumes`` hook folds extra sources into a single edge.
+
+    The iterated source plus every consumed source share one translated edge,
+    and all of them are marked claimed (none fall through to ``unclaimed``).
+    """
+    from fixtures.source_system import BusComponent, LineComponent
+
+    from r2x_core import Rule, apply_rules_to_context
+
+    src_bus = next(source_system.get_components(BusComponent))
+    src_lines = list(source_system.get_components(LineComponent))
+
+    def fold_in_lines(iterated, *, context):
+        """Aggregate all lines into the bus's target node."""
+        return list(context.source_system.get_components(LineComponent))
+
+    rule = Rule(
+        source_type="BusComponent",
+        target_type="NodeComponent",
+        version=3,
+        field_map={"name": "name", "uuid": "uuid"},
+        consumes=fold_in_lines,
+    )
+
+    ctx = _preserve_context([rule], source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    record = ctx.target_system.translation_history[0]
+    bus_edges = [e for e in record.edges if src_bus.uuid in e.source_uuids]
+    assert len(bus_edges) == 1
+    edge = bus_edges[0]
+    assert edge.status == "translated"
+    # Iterated bus + all consumed lines on one edge.
+    for line in src_lines:
+        assert line.uuid in edge.source_uuids
+    # Consumed lines are claimed, so they are not separately unclaimed.
+    line_only_edges = [
+        e for e in record.edges if any(line.uuid in e.source_uuids for line in src_lines) and e is not edge
+    ]
+    assert line_only_edges == []
+
+
+def test_consumes_hook_failure_surfaces_as_rule_error(source_system, target_system) -> None:
+    """A raising ``consumes`` hook fails the rule rather than corrupting the ledger."""
+    from r2x_core import Rule, apply_rules_to_context
+
+    def boom(iterated, *, context):
+        raise RuntimeError("kaboom")
+
+    rule = Rule(
+        source_type="BusComponent",
+        target_type="NodeComponent",
+        version=1,
+        field_map={"name": "name", "uuid": "uuid"},
+        consumes=boom,
+    )
+    ctx = _preserve_context([rule], source_system, target_system)
+    result = apply_rules_to_context(ctx)
+    assert result.failed_rules == 1
+
+
+def test_consumes_hook_non_list_return_is_rule_error(source_system, target_system) -> None:
+    """A ``consumes`` hook that returns a non-list is rejected."""
+    from r2x_core import Rule, apply_rules_to_context
+
+    def bad(iterated, *, context):
+        return "not-a-list"
+
+    rule = Rule(
+        source_type="BusComponent",
+        target_type="NodeComponent",
+        version=1,
+        field_map={"name": "name", "uuid": "uuid"},
+        consumes=bad,
+    )
+    ctx = _preserve_context([rule], source_system, target_system)
+    result = apply_rules_to_context(ctx)
+    assert result.failed_rules == 1
+
+
+def test_fan_out_produces_one_edge_with_multiple_targets(source_system, target_system) -> None:
+    """A one-to-many rule records a single edge listing all produced targets."""
+    from fixtures.source_system import BusComponent
+
+    from r2x_core import Rule, apply_rules_to_context
+
+    src_bus = next(source_system.get_components(BusComponent))
+    # One source bus fans out into a NodeComponent and a CircuitComponent.
+    rule = Rule(
+        source_type="BusComponent",
+        target_type=["NodeComponent", "CircuitComponent"],
+        version=1,
+        field_map={"name": "name", "uuid": "uuid"},
+    )
+    ctx = _preserve_context([rule], source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    record = ctx.target_system.translation_history[0]
+    bus_edges = [e for e in record.edges if src_bus.uuid in e.source_uuids]
+    assert len(bus_edges) == 1
+    assert bus_edges[0].status == "translated"
+    # Two targets, both with fresh (regenerated) UUIDs, on one edge.
+    assert len(bus_edges[0].target_uuids) == 2
+    assert src_bus.uuid not in bus_edges[0].target_uuids
+
+
+def test_iter_translated_components_yields_tagged_targets(rules_simple, source_system, target_system) -> None:
+    """iter_translated_components yields exactly the rule-produced components."""
+    from r2x_core import apply_rules_to_context
+
+    ctx = _preserve_context(rules_simple, source_system, target_system)
+    apply_rules_to_context(ctx)
+
+    translated = list(ctx.target_system.iter_translated_components())
+    assert translated
+    # Every yielded component carries a SourceProvenance tag.
+    from r2x_core.provenance import SourceProvenance
+
+    for component in translated:
+        tags = ctx.target_system.get_supplemental_attributes_with_component(
+            component, supplemental_attribute_type=SourceProvenance
+        )
+        assert len(tags) == 1
+
+
+def test_malformed_history_non_list_is_ignored() -> None:
+    """A non-list translation_history payload is ignored, not fatal."""
+    system = System(system_base=100.0, name="src")
+    system.add_component(SnapshotProbe(name="a"))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "sys.json"
+        system.to_json(path)
+        body = _json_body(path)
+        body["translation_history"] = {"not": "a list"}
+        path.write_bytes(orjson.dumps(body))
+        loaded = System.from_json(path)
+
+    assert loaded.translation_history == []
+    assert not loaded.has_unparsed_translation_history()
+
+
+def test_preserve_source_off_captures_no_history(rules_simple, source_system, target_system) -> None:
+    """Without preserve_source, no hop record is captured (C6)."""
+    from r2x_core import PluginConfig, PluginContext, apply_rules_to_context
+
+    ctx = PluginContext(
+        source_system=source_system,
+        target_system=target_system,
+        config=PluginConfig(models=("fixtures.source_system", "fixtures.target_system")),
+        rules=rules_simple,
+        preserve_source=False,
+    )
+    apply_rules_to_context(ctx)
+
+    assert ctx.target_system.translation_history == []


### PR DESCRIPTION
   Add an opt-in translation history (the lens complement) so a future reverse
   translation can reconstruct the source. Collapses SourceProvenance to a pure
   1:1 identity tag and removes the unreleased graph-polluting carry-over path.

   - HopRecord/HopEdge/SystemSnapshot: append-only per-hop stack, arity-as-data
     edges (translated/dropped/unclaimed), infrasys-form snapshots, mapped-field
     baselines, versioned envelope with lenient forward-compat load
   - Rule.consumes hook for many-to-one aggregation the executor cannot infer
   - Executor records one edge per rule application (fixes fan-out double-record)
   - System.translation_history serialize/deserialize, byte-identical when off
   - Rewrite lossless-translation docs to match the implementation
