### PR TITLE
feat: Add safe timeseries association replacement

### DIFF
--- a/docs/source/how-tos/attach-timeseries.md
+++ b/docs/source/how-tos/attach-timeseries.md
@@ -96,6 +96,16 @@ Use {py:func}`~r2x_core.transfer_time_series_metadata` to transfer time series m
 'Transfer time series metadata for target system.'
 ```
 
+## Replace a Time Series Association
+
+Use {py:func}`~r2x_core.replace_single_time_series` to replace one target association while preserving backing data that may be shared with the source system:
+
+```python doctest
+>>> from r2x_core import replace_single_time_series
+>>> replace_single_time_series.__doc__.splitlines()[0]
+'Replace exactly one time series association without removing shared data.'
+```
+
 ## See Also
 
 - {doc}`manage-datastores` - Manage collections of files
@@ -103,4 +113,5 @@ Use {py:func}`~r2x_core.transfer_time_series_metadata` to transfer time series m
 - {doc}`process-file-data` - Apply time series transformations
 - {py:class}`~r2x_core.FileInfo` - File metadata class
 - {py:class}`~r2x_core.DataStore` - DataStore API reference
+- {py:func}`~r2x_core.replace_single_time_series` - Replace one time series association
 - {py:func}`~r2x_core.transfer_time_series_metadata` - Transfer metadata function

--- a/docs/source/references/api.md
+++ b/docs/source/references/api.md
@@ -152,6 +152,10 @@ True
 ```
 
 ```{eval-rst}
+.. autofunction:: r2x_core.replace_single_time_series
+```
+
+```{eval-rst}
 .. autofunction:: r2x_core.transfer_time_series_metadata
 ```
 

--- a/src/r2x_core/__init__.py
+++ b/src/r2x_core/__init__.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from .rules_executor import apply_rules_to_context, apply_single_rule
     from .store import DataStore
     from .system import System
-    from .time_series import transfer_time_series_metadata
+    from .time_series import replace_single_time_series, transfer_time_series_metadata
     from .units import HasPerUnit, HasUnits, Unit, UnitSystem, get_unit_system, set_unit_system
     from .utils import (
         UpgradeStep,
@@ -93,6 +93,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "apply_single_rule": ".rules_executor",
     "DataStore": ".store",
     "System": ".system",
+    "replace_single_time_series": ".time_series",
     "transfer_time_series_metadata": ".time_series",
     "HasPerUnit": ".units",
     "HasUnits": ".units",
@@ -178,6 +179,7 @@ __all__ = [
     "h5_readers",
     "is_err",
     "is_ok",
+    "replace_single_time_series",
     "resolve_getter",
     "run_upgrade_step",
     "set_unit_system",

--- a/src/r2x_core/time_series.py
+++ b/src/r2x_core/time_series.py
@@ -306,11 +306,14 @@ def replace_single_time_series(
             except Exception as exc:
                 store.metadata_conn.rollback()
                 error = exc
-    finally:
+    except Exception:
         metadata_store._cache_metadata.clear()
         metadata_store._load_metadata_into_memory()
+        raise
 
     if error is not None:
+        metadata_store._cache_metadata.clear()
+        metadata_store._load_metadata_into_memory()
         raise error.with_traceback(error.__traceback__)
 
 

--- a/src/r2x_core/time_series.py
+++ b/src/r2x_core/time_series.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from sqlite3 import Connection
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
+from infrasys import SingleTimeSeries
 from loguru import logger
 
 if TYPE_CHECKING:
+    from infrasys import Component
+
     from .plugin_context import PluginContext
+    from .system import System
 
 
 @dataclass(frozen=True, slots=True)
@@ -261,6 +265,53 @@ def _finalize_transfer(tgt_metadata: Connection) -> None:
         )
         """
     )
+
+
+def replace_single_time_series(
+    system: System,
+    owner: Component,
+    time_series: SingleTimeSeries,
+    **features: Any,
+) -> None:
+    """Replace exactly one time series association without removing shared data.
+
+    The metadata change is rolled back if storing the replacement fails. This
+    preserves the existing association and any backing data shared with another
+    system.
+    """
+    metadata = system.list_time_series_metadata(
+        owner,
+        name=time_series.name,
+        time_series_type=SingleTimeSeries,
+        **features,
+    )
+    if len(metadata) != 1:
+        raise ValueError(
+            f"Expected one SingleTimeSeries named '{time_series.name}' on {owner.name}, found {len(metadata)}"
+        )
+
+    metadata_store = system.time_series.metadata_store
+    error: Exception | None = None
+    try:
+        with system.open_time_series_store(mode="a") as store:
+            try:
+                metadata_store.remove(
+                    owner,
+                    name=time_series.name,
+                    time_series_type=SingleTimeSeries.__name__,
+                    connection=store.metadata_conn,
+                    **features,
+                )
+                system.add_time_series(time_series, owner, **features)
+            except Exception as exc:
+                store.metadata_conn.rollback()
+                error = exc
+    finally:
+        metadata_store._cache_metadata.clear()
+        metadata_store._load_metadata_into_memory()
+
+    if error is not None:
+        raise error.with_traceback(error.__traceback__)
 
 
 def transfer_time_series_metadata(context: PluginContext) -> TimeSeriesTransferResult:

--- a/tests/test_translation_time_series.py
+++ b/tests/test_translation_time_series.py
@@ -6,11 +6,21 @@ import sqlite3
 from typing import Any, cast
 from uuid import uuid4
 
+import numpy as np
 import pytest
+from fixtures.source_system import BusComponent
 from fixtures.target_system import NodeComponent
+from infrasys import SingleTimeSeries
+from infrasys.time_series_manager import TimeSeriesManager
+from infrasys.time_series_models import TimeSeriesStorageType
+from infrasys.utils.sqlite import create_in_memory_db
 
-from r2x_core import PluginContext, apply_rules_to_context
-from r2x_core.time_series import _main_db_path, transfer_time_series_metadata
+from r2x_core import PluginContext, System, apply_rules_to_context
+from r2x_core.time_series import (
+    _main_db_path,
+    replace_single_time_series,
+    transfer_time_series_metadata,
+)
 
 
 def test_time_series_transfer_via_fixture_context(context_example: PluginContext):
@@ -30,6 +40,87 @@ def test_time_series_transfer_via_fixture_context(context_example: PluginContext
     for node in nodes_with_ts:
         keys = target_system.list_time_series_keys(node)
         assert keys
+
+
+def test_replace_single_time_series_preserves_shared_source_data(context_example: PluginContext):
+    """Replacing a target association preserves shared source data."""
+    source_system = context_example.source_system
+    assert source_system is not None
+    source_bus = source_system.get_component(BusComponent, "bus_a")
+    original = source_system.get_time_series(source_bus, name="load_profile")
+    manager = TimeSeriesManager(
+        create_in_memory_db(),
+        time_series_directory=source_system.get_time_series_directory(),
+        time_series_storage_type=TimeSeriesStorageType.ARROW,
+        permanent=True,
+    )
+    target_system = System(name="TargetFixture", time_series_manager=manager)
+    target_bus = source_bus.model_copy(deep=True)
+    target_system.add_component(target_bus)
+    context = context_example.evolve(target_system=target_system)
+    transfer_time_series_metadata(context)
+    replacement = SingleTimeSeries.from_array(
+        data=original.data_array / 100.0,
+        name=original.name,
+        initial_timestamp=original.initial_timestamp,
+        resolution=original.resolution,
+    )
+
+    replace_single_time_series(target_system, target_bus, replacement)
+
+    replaced = target_system.get_time_series(target_bus, name="load_profile")
+    preserved = source_system.get_time_series(source_bus, name="load_profile")
+    np.testing.assert_allclose(replaced.data_array, replacement.data_array)
+    np.testing.assert_allclose(preserved.data_array, original.data_array)
+    assert replaced.uuid == replacement.uuid
+    assert preserved.uuid == original.uuid
+
+
+def test_replace_single_time_series_requires_one_match(context_example: PluginContext):
+    """Replacement requires one matching association."""
+    source_system = context_example.source_system
+    assert source_system is not None
+    source_bus = source_system.get_component(BusComponent, "bus_a")
+    original = source_system.get_time_series(source_bus, name="load_profile")
+    replacement = SingleTimeSeries.from_array(
+        data=original.data_array,
+        name="missing_profile",
+        initial_timestamp=original.initial_timestamp,
+        resolution=original.resolution,
+    )
+
+    with pytest.raises(ValueError, match="found 0"):
+        replace_single_time_series(source_system, source_bus, replacement)
+
+
+def test_replace_single_time_series_restores_association_on_storage_failure(
+    context_example: PluginContext, tmp_path
+):
+    """A storage failure restores the existing association."""
+    source_system = context_example.source_system
+    assert source_system is not None
+    source_bus = source_system.get_component(BusComponent, "bus_a")
+    original = source_system.get_time_series(source_bus, name="load_profile")
+    replacement = SingleTimeSeries.from_array(
+        data=original.data_array / 100.0,
+        name=original.name,
+        initial_timestamp=original.initial_timestamp,
+        resolution=original.resolution,
+    )
+    storage_directory = source_system.get_time_series_directory()
+    assert storage_directory is not None
+    unavailable_directory = tmp_path / "unavailable"
+    storage_directory.rename(unavailable_directory)
+
+    try:
+        with pytest.raises(OSError):
+            replace_single_time_series(source_system, source_bus, replacement)
+    finally:
+        unavailable_directory.rename(storage_directory)
+
+    restored = source_system.get_time_series(source_bus, name="load_profile")
+    np.testing.assert_allclose(restored.data_array, original.data_array)
+    assert restored.uuid == original.uuid
 
 
 def test_time_series_transfer_is_idempotent(context_example: PluginContext):


### PR DESCRIPTION
This PR adds a reusable r2x-core operation for replacing a `SingleTimeSeries` association without deleting backing data that may be shared with a source system. The replacement is performed within the existing timeseries transaction context.