### PR TITLE
feat: support columnar HDF5 groups

### DIFF
--- a/src/r2x_core/exceptions.py
+++ b/src/r2x_core/exceptions.py
@@ -21,6 +21,10 @@ class ReaderError(R2XCoreError):
     """Exception raised for data reading related errors."""
 
 
+class HDF5GroupNotFoundError(KeyError):
+    """Exception raised when a configured HDF5 group is missing."""
+
+
 class MultipleFileError(ValueError):
     """Exception raised when a glob pattern matches multiple files."""
 

--- a/src/r2x_core/file_readers.py
+++ b/src/r2x_core/file_readers.py
@@ -80,10 +80,12 @@ def _(file_type_class: H5Format, *, file_path: Path, **reader_kwargs: Any) -> La
     reader_kwargs: dict[str, Any]
         Configuration describing the H5 file structure. Common options:
 
-        - **data_key** (str): Key for main data array
-        - **columns_key** (str): Key for column names dataset
-        - **index_key** (str): Key for index data
-        - **datetime_key** (str): Key for datetime strings that need parsing
+        - **group_key** (str): Optional HDF5 group to read from.
+        - **data_key** (str): Key for main data array.
+        - **columns_key** (str): Key for column names dataset.
+        - **columns_as_datasets** (bool): Treat each column name as a dataset in the selected group.
+        - **index_key** (str): Key for index data.
+        - **datetime_key** (str): Key for datetime strings that need parsing.
         - **additional_keys** (list[str]): Additional datasets to include as columns
         - **decode_bytes** (bool): Whether to decode byte strings (default: True)
         - **strip_timezone** (bool): Whether to strip timezone info (default: True)

--- a/src/r2x_core/h5_readers.py
+++ b/src/r2x_core/h5_readers.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime
 import h5py
 import numpy as np
 
+from .exceptions import HDF5GroupNotFoundError
+
 H5Value = np.ndarray | list[str]
 H5Result = dict[str, H5Value]
 DEFAULT_DATETIME_COLUMN_NAME = "datetime"
@@ -32,7 +34,7 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
     if isinstance(group_key, str):
         selected = h5_file.get(group_key)
         if selected is None:
-            raise KeyError(f"HDF5 group '{group_key}' not found")
+            raise HDF5GroupNotFoundError(f"HDF5 group '{group_key}' not found")
         if not isinstance(selected, h5py.Group):
             raise TypeError(f"HDF5 path '{group_key}' is not a group")
         scope = selected

--- a/src/r2x_core/h5_readers.py
+++ b/src/r2x_core/h5_readers.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from .exceptions import HDF5GroupNotFoundError
 
-H5Value = np.ndarray | list[str]
+H5Label = str | bytes
+H5Value = np.ndarray | list[str] | list[bytes]
 H5Result = dict[str, H5Value]
 DEFAULT_DATETIME_COLUMN_NAME = "datetime"
 DEFAULT_INDEX_NAMES_KEY = "index_names"
@@ -46,6 +47,10 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
     data_key = reader_kwargs.get("data_key")
     if data_key is not None and (not isinstance(data_key, str) or not data_key):
         raise ValueError("data_key is required and must be a non-empty string")
+
+    decode_bytes = reader_kwargs.get("decode_bytes", True)
+    if not isinstance(decode_bytes, bool):
+        raise ValueError("decode_bytes must be a boolean")
     if data_key is None and not columns_as_datasets:
         return read_first_dataset(scope)
 
@@ -61,15 +66,15 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
         file_data[key] = dataset
 
     index_names_dataset = get_h5_dataset(scope, file_data, index_names_key)
+    index_names: list[H5Label] | None = None
     if index_names_dataset is not None:
-        index_values = index_names_dataset[()]
-        if index_names_dataset.dtype.kind in HDF5_STRING_KINDS:
-            index_values = index_names_dataset.asstr()[()]
-        index_names = [str(value) for value in np.atleast_1d(index_values)]
+        index_names = read_h5_labels(index_names_dataset, decode_bytes=decode_bytes)
         for index_number, index_name in enumerate(index_names):
-            resolved_key = f"{INDEX_COLUMN_PREFIX}{index_name}"
-            dataset_key = resolved_key if resolved_key in scope else f"{INDEX_COLUMN_PREFIX}{index_number}"
-            resolved_dataset = scope.get(dataset_key)
+            resolved_key = make_index_key(index_name)
+            resolved_dataset = scope.get(h5_key_to_string(resolved_key))
+            if not isinstance(resolved_dataset, h5py.Dataset):
+                fallback_key = f"{INDEX_COLUMN_PREFIX}{index_number}"
+                resolved_dataset = scope.get(fallback_key)
             if not isinstance(resolved_dataset, h5py.Dataset):
                 raise KeyError(f"Missing index dataset referenced by {resolved_key}")
             file_data[resolved_key] = resolved_dataset
@@ -77,10 +82,6 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
     columns_key = reader_kwargs.get("columns_key")
     if columns_key is not None and not isinstance(columns_key, str):
         raise ValueError("columns_key must be a string")
-
-    decode_bytes = reader_kwargs.get("decode_bytes", True)
-    if not isinstance(decode_bytes, bool):
-        raise ValueError("decode_bytes must be a boolean")
 
     if columns_as_datasets:
         result: H5Result = read_columnar_group(
@@ -98,29 +99,28 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
         result = {}
         columns = get_h5_dataset(scope, file_data, columns_key) if isinstance(columns_key, str) else None
         if isinstance(columns, h5py.Dataset):
-            column_values = columns.asstr()[()]
-            column_names = [str(value) for value in np.atleast_1d(column_values)]
+            column_names = read_h5_labels(columns, decode_bytes=decode_bytes)
             if data.ndim == 2:
                 if len(column_names) != data.shape[1]:
                     raise ValueError(
                         f"columns_key '{columns_key}' contains {len(column_names)} names "
                         f"for data with {data.shape[1]} columns"
                     )
-                result = {column: data[:, i] for i, column in enumerate(column_names)}
+                result = {h5_key_to_string(column): data[:, i] for i, column in enumerate(column_names)}
             else:
                 if len(column_names) != 1:
                     raise ValueError(
                         f"columns_key '{columns_key}' must contain exactly 1 name "
                         f"for 1D data, found {len(column_names)}"
                     )
-                result[column_names[0]] = data
+                result[h5_key_to_string(column_names[0])] = data
         elif data.ndim == 1:
             result[data_key] = data
         else:
             result = {f"{data_key}_col_{i}": data[:, i] for i in range(data.shape[1])}
 
     raw_mapping = reader_kwargs.get("column_name_mapping")
-    column_mapping: dict[str, str] = {}
+    column_mapping: dict[str, H5Label] = {}
     if raw_mapping is not None:
         if not isinstance(raw_mapping, dict):
             raise ValueError("column_name_mapping must be a dictionary")
@@ -129,8 +129,7 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
                 raise ValueError("column_name_mapping must map strings to strings")
             column_mapping[key] = value
     user_column_mapping = bool(column_mapping)
-    if not user_column_mapping and index_names_dataset is not None:
-        index_names = read_h5_strings(index_names_dataset)
+    if not user_column_mapping and index_names is not None:
         column_mapping = {f"{INDEX_COLUMN_PREFIX}{i}": name for i, name in enumerate(index_names)}
 
     datetime_key = reader_kwargs.get("datetime_key")
@@ -148,8 +147,8 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
         dt_values = datetime_dataset[()]
         if decode_bytes and datetime_dataset.dtype.kind in HDF5_STRING_KINDS:
             dt_values = datetime_dataset.asstr()[()]
-        dt_data = np.asarray(dt_values)
-        if len(dt_data) > 0 and isinstance(dt_data[0], str):
+        dt_data = np.atleast_1d(np.asarray(dt_values))
+        if dt_data.size > 0 and isinstance(dt_data[0], str):
             result[datetime_name] = parse_datetime_array(
                 [str(value) for value in dt_data],
                 strip_timezone,
@@ -181,7 +180,7 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
             column_name = format_column_name(key)
         elif not user_column_mapping:
             column_name = format_column_name(column_name)
-        result[column_name] = np.asarray(additional_dataset[()])
+        result[h5_key_to_string(column_name)] = np.asarray(additional_dataset[()])
 
     return result
 
@@ -194,16 +193,31 @@ def get_h5_dataset(
     """Resolve a direct dataset, an index alias, or an HDF5 path."""
     dataset = datasets.get(key)
     if dataset is None:
-        selected = scope.get(key)
+        selected = scope.get(h5_key_to_string(key))
         if isinstance(selected, h5py.Dataset):
             dataset = selected
     return dataset
 
 
-def read_h5_strings(dataset: h5py.Dataset) -> list[str]:
-    """Read an HDF5 dataset of labels as Python strings."""
-    values = dataset.asstr()[()] if dataset.dtype.kind in HDF5_STRING_KINDS else dataset[()]
-    return [str(value) for value in np.atleast_1d(values)]
+def read_h5_labels(dataset: h5py.Dataset, *, decode_bytes: bool) -> list[H5Label]:
+    """Read an HDF5 dataset of labels with optional byte-string decoding."""
+    values = dataset[()]
+    if decode_bytes and dataset.dtype.kind in HDF5_STRING_KINDS:
+        values = dataset.asstr()[()]
+    labels = np.atleast_1d(values)
+    if decode_bytes:
+        return [str(value) for value in labels]
+    return [value if isinstance(value, bytes) else str(value) for value in labels]
+
+
+def make_index_key(index_name: H5Label) -> str:
+    """Build the HDF5 dataset key for a named index."""
+    return f"{INDEX_COLUMN_PREFIX}{h5_key_to_string(index_name)}"
+
+
+def h5_key_to_string(key: H5Label) -> str:
+    """Convert an HDF5 string key to the text form accepted by h5py."""
+    return key.decode() if isinstance(key, bytes) else key
 
 
 def read_columnar_group(
@@ -213,28 +227,36 @@ def read_columnar_group(
     decode_bytes: bool,
 ) -> H5Result:
     """Read one HDF5 dataset for each name listed in a group's columns dataset."""
-    if columns_key is None or columns_key not in scope:
+    if columns_key is None:
         raise ValueError("columns_key is required when columns_as_datasets is enabled")
 
     columns_dataset = scope.get(columns_key)
+    if columns_dataset is None:
+        raise ValueError(f"HDF5 columns path '{columns_key}' not found")
     if not isinstance(columns_dataset, h5py.Dataset):
         raise TypeError(f"HDF5 columns path '{columns_key}' is not a dataset")
 
     result: H5Result = {}
-    for column in read_h5_strings(columns_dataset):
-        dataset = scope.get(column)
+    for column in read_h5_labels(columns_dataset, decode_bytes=decode_bytes):
+        column_key = h5_key_to_string(column)
+        dataset = scope.get(column_key)
         if not isinstance(dataset, h5py.Dataset):
-            raise KeyError(f"HDF5 column dataset '{column}' not found")
-        if decode_bytes and dataset.dtype.kind in HDF5_STRING_KINDS:
-            result[column] = [str(value) for value in np.atleast_1d(dataset.asstr()[()])]
+            raise KeyError(f"HDF5 column dataset '{h5_key_to_string(column)}' not found")
+        if dataset.dtype.kind in HDF5_STRING_KINDS:
+            values = np.atleast_1d(dataset.asstr()[()]) if decode_bytes else np.atleast_1d(dataset[()])
+            result[column_key] = values.tolist()
         else:
-            result[column] = np.atleast_1d(np.asarray(dataset[()]))
+            result[column_key] = np.atleast_1d(np.asarray(dataset[()]))
     return result
 
 
 def read_first_dataset(scope: h5py.Group) -> H5Result:
     """Read first dataset in an HDF5 scope as the default behavior."""
-    key = next(iter(scope.keys()))
+    try:
+        key = next(iter(scope.keys()))
+    except StopIteration as exc:
+        raise ValueError("HDF5 scope contains no datasets") from exc
+
     dataset = scope[key]
     if not isinstance(dataset, h5py.Dataset):
         return {key: [str(dataset)]}
@@ -267,8 +289,10 @@ def parse_datetime_array(dt_strings: Sequence[str], strip_timezone: bool) -> np.
     return np.array(parsed, dtype="datetime64[us]")
 
 
-def format_column_name(key: str) -> str:
+def format_column_name(key: H5Label) -> str:
     """Format HDF5 dataset key into a clean column name."""
+    if isinstance(key, bytes):
+        key = key.decode()
     key_lower = key.lower()
     if "index_year" in key_lower or key_lower == SOLVE_YEAR_COLUMN_NAME:
         return SOLVE_YEAR_COLUMN_NAME

--- a/src/r2x_core/h5_readers.py
+++ b/src/r2x_core/h5_readers.py
@@ -106,6 +106,11 @@ def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Res
                     )
                 result = {column: data[:, i] for i, column in enumerate(column_names)}
             else:
+                if len(column_names) != 1:
+                    raise ValueError(
+                        f"columns_key '{columns_key}' must contain exactly 1 name "
+                        f"for 1D data, found {len(column_names)}"
+                    )
                 result[column_names[0]] = data
         elif data.ndim == 1:
             result[data_key] = data
@@ -220,7 +225,7 @@ def read_columnar_group(
             raise KeyError(f"HDF5 column dataset '{column}' not found")
         values: np.ndarray = np.atleast_1d(np.asarray(dataset[()]))
         if decode_bytes and values.dtype.kind in HDF5_STRING_KINDS:
-            result[column] = [str(value) for value in dataset.asstr()[()]]
+            result[column] = [str(value) for value in np.atleast_1d(dataset.asstr()[()])]
         else:
             result[column] = values
     return result

--- a/src/r2x_core/h5_readers.py
+++ b/src/r2x_core/h5_readers.py
@@ -223,11 +223,10 @@ def read_columnar_group(
         dataset = scope.get(column)
         if not isinstance(dataset, h5py.Dataset):
             raise KeyError(f"HDF5 column dataset '{column}' not found")
-        values: np.ndarray = np.atleast_1d(np.asarray(dataset[()]))
-        if decode_bytes and values.dtype.kind in HDF5_STRING_KINDS:
+        if decode_bytes and dataset.dtype.kind in HDF5_STRING_KINDS:
             result[column] = [str(value) for value in np.atleast_1d(dataset.asstr()[()])]
         else:
-            result[column] = values
+            result[column] = np.atleast_1d(np.asarray(dataset[()]))
     return result
 
 

--- a/src/r2x_core/h5_readers.py
+++ b/src/r2x_core/h5_readers.py
@@ -1,186 +1,271 @@
-"""Flexible, configuration-driven HDF5 reader.
+"""Flexible, configuration-driven HDF5 reader."""
 
-This module provides a generic H5 reader that adapts to any file structure
-through configuration parameters, without hardcoded model-specific logic.
-"""
-
+from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any
 
+import h5py
 import numpy as np
 
+H5Value = np.ndarray | list[str]
+H5Result = dict[str, H5Value]
+DEFAULT_DATETIME_COLUMN_NAME = "datetime"
+DEFAULT_INDEX_NAMES_KEY = "index_names"
+HDF5_STRING_KINDS = frozenset({"S", "O"})
+INDEX_COLUMN_PREFIX = "index_"
+SOLVE_YEAR_COLUMN_NAME = "solve_year"
+YEAR_COLUMN_NAME = "year"
 
-def configurable_h5_reader(h5_file: Any, **reader_kwargs: Any) -> dict[str, Any]:
-    """H5 reader that adapts to any file structure via configuration.
 
-    Parameters
-    ----------
-    h5_file : h5py.File
-        Open HDF5 file handle.
-    **reader_kwargs : dict
-        Configuration: data_key, columns_key, index_key, datetime_key,
-        datetime_column_name (default: "datetime"), additional_keys,
-        decode_bytes (default: True), strip_timezone (default: True),
-        column_name_mapping (optional: dict mapping dataset keys to column names),
-        index_names_key (default: "index_names").
+def configurable_h5_reader(h5_file: h5py.File, **reader_kwargs: object) -> H5Result:
+    """Read an HDF5 dataset or a configured columnar group.
 
-    Returns
-    -------
-    dict[str, Any]
-        Dictionary mapping column names to data arrays.
-
-    Notes
-    -----
-    The reader supports automatic column name resolution from an index_names
-    dataset (e.g., for newer ReEDS format files where indices are named
-    index_0, index_1, etc.). The index_names dataset should contain the
-    actual names for these generic indices.
-
-    If column_name_mapping is provided, it takes precedence over index_names.
+    ``data_key`` and ``columns_key`` describe row-oriented data. Set
+    ``group_key`` to read within a group and ``columns_as_datasets`` when each
+    column is a dataset named in ``columns_key``. ``datetime_key``,
+    ``index_key``, and ``additional_keys`` add supporting columns.
     """
-    if not reader_kwargs or not reader_kwargs.get("data_key"):
-        return _read_first_dataset(h5_file)
+    group_key = reader_kwargs.get("group_key")
+    if group_key is not None and not isinstance(group_key, str):
+        raise ValueError("group_key must be a string")
 
-    file_data = {}
-    for key in h5_file:
-        if key == "index_names":
-            # Populate file_data using the actual index datasets referenced by
-            # index_names rather than assuming `index_<n>` always exists.
-            index_names = [f"index_{name.decode()}" for name in h5_file["index_names"]]
-            for index_num, index_name in enumerate(index_names):
-                dataset_key = index_name if index_name in h5_file else f"index_{index_num}"
-                if dataset_key not in h5_file:
-                    raise KeyError(f"Missing index dataset referenced by {index_name}")
-                file_data[index_name] = h5_file[dataset_key]
-        else:
-            file_data[key] = h5_file[key]
+    scope: h5py.Group = h5_file
+    if isinstance(group_key, str):
+        selected = h5_file.get(group_key)
+        if selected is None:
+            raise KeyError(f"HDF5 group '{group_key}' not found")
+        if not isinstance(selected, h5py.Group):
+            raise TypeError(f"HDF5 path '{group_key}' is not a group")
+        scope = selected
 
-    data_key = reader_kwargs["data_key"]
+    columns_as_datasets = reader_kwargs.get("columns_as_datasets", False)
+    if not isinstance(columns_as_datasets, bool):
+        raise ValueError("columns_as_datasets must be a boolean")
+
+    data_key = reader_kwargs.get("data_key")
+    if data_key is not None and (not isinstance(data_key, str) or not data_key):
+        raise ValueError("data_key is required and must be a non-empty string")
+    if data_key is None and not columns_as_datasets:
+        return read_first_dataset(scope)
+
+    index_names_key = reader_kwargs.get("index_names_key", DEFAULT_INDEX_NAMES_KEY)
+    if not isinstance(index_names_key, str):
+        raise ValueError("index_names_key must be a string")
+
+    file_data: dict[str, h5py.Dataset] = {}
+    for key in scope:
+        dataset = scope[key]
+        if not isinstance(dataset, h5py.Dataset):
+            continue
+        file_data[key] = dataset
+
+    index_names_dataset = get_h5_dataset(scope, file_data, index_names_key)
+    if index_names_dataset is not None:
+        index_values = index_names_dataset[()]
+        if index_names_dataset.dtype.kind in HDF5_STRING_KINDS:
+            index_values = index_names_dataset.asstr()[()]
+        index_names = [str(value) for value in np.atleast_1d(index_values)]
+        for index_number, index_name in enumerate(index_names):
+            resolved_key = f"{INDEX_COLUMN_PREFIX}{index_name}"
+            dataset_key = resolved_key if resolved_key in scope else f"{INDEX_COLUMN_PREFIX}{index_number}"
+            resolved_dataset = scope.get(dataset_key)
+            if not isinstance(resolved_dataset, h5py.Dataset):
+                raise KeyError(f"Missing index dataset referenced by {resolved_key}")
+            file_data[resolved_key] = resolved_dataset
+
     columns_key = reader_kwargs.get("columns_key")
+    if columns_key is not None and not isinstance(columns_key, str):
+        raise ValueError("columns_key must be a string")
+
     decode_bytes = reader_kwargs.get("decode_bytes", True)
+    if not isinstance(decode_bytes, bool):
+        raise ValueError("decode_bytes must be a boolean")
 
-    data = file_data[data_key][:]
-    result: dict[str, Any] = {}
-
-    if columns_key and columns_key in file_data:
-        columns = file_data[columns_key][:]
-        if decode_bytes and columns.dtype.kind == "S":
-            columns = columns.astype(str)
-        if data.ndim == 2:
-            result = {col: data[:, i] for i, col in enumerate(columns)}
-        else:
-            result[columns[0]] = data
+    if columns_as_datasets:
+        result: H5Result = read_columnar_group(
+            scope,
+            columns_key=columns_key,
+            decode_bytes=decode_bytes,
+        )
     else:
-        if data.ndim == 1:
+        if not isinstance(data_key, str):
+            raise ValueError("data_key is required when columns_as_datasets is disabled")
+        data_dataset = get_h5_dataset(scope, file_data, data_key)
+        if data_dataset is None:
+            raise KeyError(f"HDF5 dataset '{data_key}' not found")
+        data = np.asarray(data_dataset[()])
+        result = {}
+        columns = get_h5_dataset(scope, file_data, columns_key) if isinstance(columns_key, str) else None
+        if isinstance(columns, h5py.Dataset):
+            column_values = columns.asstr()[()]
+            column_names = [str(value) for value in np.atleast_1d(column_values)]
+            if data.ndim == 2:
+                if len(column_names) != data.shape[1]:
+                    raise ValueError(
+                        f"columns_key '{columns_key}' contains {len(column_names)} names "
+                        f"for data with {data.shape[1]} columns"
+                    )
+                result = {column: data[:, i] for i, column in enumerate(column_names)}
+            else:
+                result[column_names[0]] = data
+        elif data.ndim == 1:
             result[data_key] = data
         else:
             result = {f"{data_key}_col_{i}": data[:, i] for i in range(data.shape[1])}
 
-    # Build column name mapping from index_names dataset if present
-    column_mapping = reader_kwargs.get("column_name_mapping")
-    user_column_mapping = column_mapping is not None and len(column_mapping) > 0
-    if not column_mapping:
-        column_mapping = {}
-        index_names_key = reader_kwargs.get("index_names_key", "index_names")
-        if index_names_key in h5_file:
-            index_names = h5_file[index_names_key][:]
-            if decode_bytes and index_names.dtype.kind == "S":
-                index_names = index_names.astype(str)
-            # Map index_0, index_1, etc. to their actual names
-            for i, name in enumerate(index_names):
-                column_mapping[f"index_{i}"] = name
+    raw_mapping = reader_kwargs.get("column_name_mapping")
+    column_mapping: dict[str, str] = {}
+    if raw_mapping is not None:
+        if not isinstance(raw_mapping, dict):
+            raise ValueError("column_name_mapping must be a dictionary")
+        for key, value in raw_mapping.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError("column_name_mapping must map strings to strings")
+            column_mapping[key] = value
+    user_column_mapping = bool(column_mapping)
+    if not user_column_mapping and index_names_dataset is not None:
+        index_names = read_h5_strings(index_names_dataset)
+        column_mapping = {f"{INDEX_COLUMN_PREFIX}{i}": name for i, name in enumerate(index_names)}
 
     datetime_key = reader_kwargs.get("datetime_key")
-    if datetime_key and datetime_key in file_data:
-        dt_data = file_data[datetime_key][:]
-        if decode_bytes and dt_data.dtype.kind == "S":
-            dt_data = dt_data.astype(str)
+    if datetime_key is not None and not isinstance(datetime_key, str):
+        raise ValueError("datetime_key must be a string")
+    datetime_name = reader_kwargs.get("datetime_column_name", DEFAULT_DATETIME_COLUMN_NAME)
+    if not isinstance(datetime_name, str):
+        raise ValueError("datetime_column_name must be a string")
+    strip_timezone = reader_kwargs.get("strip_timezone", True)
+    if not isinstance(strip_timezone, bool):
+        raise ValueError("strip_timezone must be a boolean")
 
+    datetime_dataset = get_h5_dataset(scope, file_data, datetime_key) if datetime_key is not None else None
+    if datetime_dataset is not None:
+        dt_values = datetime_dataset[()]
+        if decode_bytes and datetime_dataset.dtype.kind in HDF5_STRING_KINDS:
+            dt_values = datetime_dataset.asstr()[()]
+        dt_data = np.asarray(dt_values)
         if len(dt_data) > 0 and isinstance(dt_data[0], str):
-            dt_parsed = _parse_datetime_array(dt_data, reader_kwargs.get("strip_timezone", True))
-            result[reader_kwargs.get("datetime_column_name", "datetime")] = dt_parsed
+            result[datetime_name] = parse_datetime_array(
+                [str(value) for value in dt_data],
+                strip_timezone,
+            )
         else:
-            result[reader_kwargs.get("datetime_column_name", "datetime")] = dt_data
+            result[datetime_name] = dt_data
 
     index_key = reader_kwargs.get("index_key")
-    if index_key and index_key in file_data and index_key != datetime_key:
-        result[index_key] = file_data[index_key][:]
+    if index_key is not None and not isinstance(index_key, str):
+        raise ValueError("index_key must be a string")
+    index_dataset = get_h5_dataset(scope, file_data, index_key) if index_key is not None else None
+    if isinstance(index_key, str) and index_dataset is not None and index_key != datetime_key:
+        result[index_key] = np.asarray(index_dataset[()])
 
-    for key in reader_kwargs.get("additional_keys", []):
-        if key in h5_file:
-            # Use mapped name if available; respect user overrides without reformatting.
-            if key in column_mapping:
-                mapped_name = column_mapping[key]
-                col_name = mapped_name if user_column_mapping else _format_column_name(mapped_name)
-            else:
-                col_name = _format_column_name(key)
-            result[col_name] = h5_file[key][:]
+    raw_additional_keys = reader_kwargs.get("additional_keys", [])
+    if not isinstance(raw_additional_keys, list):
+        raise ValueError("additional_keys must be a list of strings")
+    additional_keys: list[str] = []
+    for key in raw_additional_keys:
+        if not isinstance(key, str):
+            raise ValueError("additional_keys must be a list of strings")
+        additional_keys.append(key)
+    for key in additional_keys:
+        additional_dataset = get_h5_dataset(scope, file_data, key)
+        if additional_dataset is None:
+            continue
+        column_name = column_mapping.get(key)
+        if column_name is None:
+            column_name = format_column_name(key)
+        elif not user_column_mapping:
+            column_name = format_column_name(column_name)
+        result[column_name] = np.asarray(additional_dataset[()])
 
     return result
 
 
-def _read_first_dataset(h5_file: Any) -> dict[str, Any]:
-    """Read first dataset in file as default behavior."""
-    key = next(iter(h5_file.keys()))
-    dataset = h5_file[key]
+def get_h5_dataset(
+    scope: h5py.Group,
+    datasets: dict[str, h5py.Dataset],
+    key: str,
+) -> h5py.Dataset | None:
+    """Resolve a direct dataset, an index alias, or an HDF5 path."""
+    dataset = datasets.get(key)
+    if dataset is None:
+        selected = scope.get(key)
+        if isinstance(selected, h5py.Dataset):
+            dataset = selected
+    return dataset
 
-    try:
-        data = dataset[:]
-    except (TypeError, AttributeError):
+
+def read_h5_strings(dataset: h5py.Dataset) -> list[str]:
+    """Read an HDF5 dataset of labels as Python strings."""
+    values = dataset.asstr()[()] if dataset.dtype.kind in HDF5_STRING_KINDS else dataset[()]
+    return [str(value) for value in np.atleast_1d(values)]
+
+
+def read_columnar_group(
+    scope: h5py.Group,
+    *,
+    columns_key: str | None,
+    decode_bytes: bool,
+) -> H5Result:
+    """Read one HDF5 dataset for each name listed in a group's columns dataset."""
+    if columns_key is None or columns_key not in scope:
+        raise ValueError("columns_key is required when columns_as_datasets is enabled")
+
+    columns_dataset = scope.get(columns_key)
+    if not isinstance(columns_dataset, h5py.Dataset):
+        raise TypeError(f"HDF5 columns path '{columns_key}' is not a dataset")
+
+    result: H5Result = {}
+    for column in read_h5_strings(columns_dataset):
+        dataset = scope.get(column)
+        if not isinstance(dataset, h5py.Dataset):
+            raise KeyError(f"HDF5 column dataset '{column}' not found")
+        values: np.ndarray = np.atleast_1d(np.asarray(dataset[()]))
+        if decode_bytes and values.dtype.kind in HDF5_STRING_KINDS:
+            result[column] = [str(value) for value in dataset.asstr()[()]]
+        else:
+            result[column] = values
+    return result
+
+
+def read_first_dataset(scope: h5py.Group) -> H5Result:
+    """Read first dataset in an HDF5 scope as the default behavior."""
+    key = next(iter(scope.keys()))
+    dataset = scope[key]
+    if not isinstance(dataset, h5py.Dataset):
         return {key: [str(dataset)]}
 
+    data = np.atleast_1d(np.asarray(dataset[()]))
     if data.ndim == 1:
         return {key: data}
     return {f"{key}_col_{i}": data[:, i] for i in range(data.shape[1])}
 
 
-def _parse_datetime_array(dt_strings: Any, strip_timezone: bool) -> Any:
-    """Parse array of datetime strings using standard library.
-
-    Parameters
-    ----------
-    dt_strings : array-like
-        Array of datetime strings in ISO 8601 format.
-    strip_timezone : bool
-        Whether to convert timezone-aware datetimes to timezone-naive.
-        If False, converts to UTC before making naive.
-
-    Returns
-    -------
-    np.ndarray
-        Array of datetime64[us] values (always timezone-naive).
-
-    Raises
-    ------
-    ValueError
-        If datetime strings cannot be parsed.
-    """
+def parse_datetime_array(dt_strings: Sequence[str], strip_timezone: bool) -> np.ndarray:
+    """Parse ISO datetime strings into timezone-naive datetime64 values."""
     parsed: list[datetime] = []
     for i, dt_str in enumerate(dt_strings):
         try:
             dt_obj = datetime.fromisoformat(dt_str)
-
             if dt_obj.tzinfo is not None:
                 if strip_timezone:
-                    # Strip timezone info (keep local time)
                     dt_obj = dt_obj.replace(tzinfo=None)
                 else:
-                    # Convert to UTC then make naive
                     dt_obj = dt_obj.astimezone(UTC).replace(tzinfo=None)
-
             parsed.append(dt_obj)
-        except (ValueError, AttributeError) as e:
-            msg = f"Failed to parse datetime string at index {i}: '{dt_str}'. Expected ISO 8601 format. Error: {e}"
-            raise ValueError(msg) from e
+        except (ValueError, AttributeError) as exc:
+            msg = (
+                f"Failed to parse datetime string at index {i}: '{dt_str}'. "
+                f"Expected ISO 8601 format. Error: {exc}"
+            )
+            raise ValueError(msg) from exc
 
     return np.array(parsed, dtype="datetime64[us]")
 
 
-def _format_column_name(key: str) -> str:
-    """Format H5 dataset key into clean column name."""
+def format_column_name(key: str) -> str:
+    """Format HDF5 dataset key into a clean column name."""
     key_lower = key.lower()
-    if "index_year" in key_lower or key_lower == "solve_year":
-        return "solve_year"
+    if "index_year" in key_lower or key_lower == SOLVE_YEAR_COLUMN_NAME:
+        return SOLVE_YEAR_COLUMN_NAME
     if "year" in key_lower:
-        return "year"
-    return key.replace("index_", "")
+        return YEAR_COLUMN_NAME
+    return key.replace(INDEX_COLUMN_PREFIX, "")

--- a/src/r2x_core/reader.py
+++ b/src/r2x_core/reader.py
@@ -27,7 +27,7 @@ from loguru import logger
 from rust_ok import Ok
 
 from .datafile import DataFile
-from .exceptions import ReaderError
+from .exceptions import HDF5GroupNotFoundError, ReaderError
 from .file_readers import read_file_by_type
 from .file_types import EXTENSION_MAPPING
 from .processors import apply_processing, register_transformation
@@ -138,7 +138,13 @@ class DataReader:
         logger.trace(
             "Attempting to read data_file={} with {}", data_file.name, type(file_type_instance).__name__
         )
-        raw_data = read_file_by_type(file_type_instance, file_path=fpath, **reader_kwargs)
+        try:
+            raw_data = read_file_by_type(file_type_instance, file_path=fpath, **reader_kwargs)
+        except HDF5GroupNotFoundError:
+            if is_optional:
+                logger.debug("Skipping optional file with missing HDF5 group: {}", data_file.name)
+                return None
+            raise
         if data_file.proc_spec is not None:
             processed_data = apply_processing(
                 raw_data, data_file=data_file, proc_spec=data_file.proc_spec, placeholders=placeholders

--- a/tests/test_h5_readers.py
+++ b/tests/test_h5_readers.py
@@ -341,7 +341,7 @@ def test_datetime_parsing_error():
 
 
 def test_format_column_name_year():
-    """Test _format_column_name for year variations (line 134)."""
+    """Test format_column_name for year variations."""
     with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
         tmp_path = Path(tmp.name)
 
@@ -371,8 +371,8 @@ def test_h5_reader_index_names_resolves_numeric_indices():
     The index_names dataset provides the mapping, and the reader should automatically
     apply it to produce columns named "solve_year" instead of "1".
 
-    Issue: _format_column_name("index_1") was returning "1" instead of "solve_year"
-    Fix: Reader now checks for index_names dataset and maps index_N to actual names
+    Issue: formatting a generic index name returned "1" instead of "solve_year".
+    Fix: Reader now checks for index_names dataset and maps index_N to actual names.
     """
     with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
         tmp_path = Path(tmp.name)
@@ -496,3 +496,209 @@ def test_h5_reader_missing_index_dataset_raises_key_error():
             )
     finally:
         tmp_path.unlink()
+
+
+def test_h5_reader_reads_columnar_group_datasets():
+    """Read ReEDS-style groups whose columns are individual datasets."""
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with h5py.File(str(tmp_path), "w") as f:
+            group = f.create_group("fuel_price")
+            group.create_dataset("columns", data=np.array([b"i", b"r", b"Value"]))
+            group.create_dataset("i", data=np.array([b"gas", b"coal"]))
+            group.create_dataset("r", data=np.array([b"r1", b"r2"]))
+            group.create_dataset("Value", data=np.array([3.0, 4.0]))
+
+        with h5py.File(str(tmp_path), "r") as f:
+            result = configurable_h5_reader(
+                f,
+                group_key="fuel_price",
+                columns_key="columns",
+                columns_as_datasets=True,
+            )
+
+        assert result["i"] == ["gas", "coal"]
+        assert result["r"] == ["r1", "r2"]
+        np.testing.assert_array_equal(result["Value"], np.array([3.0, 4.0]))
+    finally:
+        tmp_path.unlink()
+
+
+def test_h5_reader_group_validation_errors():
+    """Reject missing groups, column metadata, and column datasets."""
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with h5py.File(str(tmp_path), "w") as f:
+            f.create_dataset("not_a_group", data=np.array([1.0]))
+            group = f.create_group("group")
+            group.create_dataset("columns", data=np.array([b"missing"]))
+
+        with h5py.File(str(tmp_path), "r") as f:
+            with pytest.raises(KeyError, match="missing_group"):
+                configurable_h5_reader(
+                    f,
+                    group_key="missing_group",
+                    columns_key="columns",
+                    columns_as_datasets=True,
+                )
+            with pytest.raises(TypeError, match="not_a_group"):
+                configurable_h5_reader(f, group_key="not_a_group")
+            with pytest.raises(KeyError, match="missing"):
+                configurable_h5_reader(
+                    f,
+                    group_key="group",
+                    columns_key="columns",
+                    columns_as_datasets=True,
+                )
+            with pytest.raises(ValueError, match="columns_key is required"):
+                configurable_h5_reader(f, group_key="group", columns_as_datasets=True)
+    finally:
+        tmp_path.unlink()
+
+
+def test_h5_reader_columnar_group_reads_scalar_dataset():
+    """Normalize scalar column datasets to one-row arrays."""
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with h5py.File(str(tmp_path), "w") as f:
+            group = f.create_group("group")
+            group.create_dataset("columns", data=np.array([b"Value"]))
+            group.create_dataset("Value", data=np.array(3.0))
+
+        with h5py.File(str(tmp_path), "r") as f:
+            result = configurable_h5_reader(
+                f,
+                group_key="group",
+                columns_key="columns",
+                columns_as_datasets=True,
+            )
+
+        np.testing.assert_array_equal(result["Value"], np.array([3.0]))
+    finally:
+        tmp_path.unlink()
+
+
+def test_h5_reader_rejects_invalid_reader_keys(tmp_path):
+    """Reject invalid key types before opening configured datasets."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([1.0]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        with pytest.raises(ValueError, match="index_names_key must be a string"):
+            configurable_h5_reader(h5_file, data_key="data", index_names_key=1)
+        with pytest.raises(ValueError, match="data_key is required"):
+            configurable_h5_reader(h5_file, data_key=1, columns_key="columns")
+
+
+def test_h5_reader_missing_data_key_raises_key_error(tmp_path):
+    """Raise KeyError when the configured main dataset does not exist."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("other", data=np.array([1.0]))
+
+    with h5py.File(h5_path, "r") as h5_file, pytest.raises(KeyError, match="missing"):
+        configurable_h5_reader(h5_file, data_key="missing")
+
+
+def test_h5_reader_validates_reader_configuration(tmp_path):
+    """Reject invalid configuration values before reading datasets."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([1.0]))
+        h5_file.create_dataset("columns", data=np.array([b"value"]))
+
+    invalid_options = [
+        ({"group_key": 1}, "group_key must be a string"),
+        ({"columns_as_datasets": "yes"}, "columns_as_datasets must be a boolean"),
+        ({"data_key": ""}, "data_key is required"),
+        ({"columns_key": 1}, "columns_key must be a string"),
+        ({"decode_bytes": "yes"}, "decode_bytes must be a boolean"),
+        ({"datetime_key": 1}, "datetime_key must be a string"),
+        ({"datetime_column_name": 1}, "datetime_column_name must be a string"),
+        ({"strip_timezone": "yes"}, "strip_timezone must be a boolean"),
+        ({"index_key": 1}, "index_key must be a string"),
+        ({"additional_keys": "data"}, "additional_keys must be a list"),
+        ({"additional_keys": [1]}, "additional_keys must be a list"),
+        ({"column_name_mapping": []}, "column_name_mapping must be a dictionary"),
+        ({"column_name_mapping": {1: "value"}}, "column_name_mapping must map strings"),
+    ]
+
+    with h5py.File(h5_path, "r") as h5_file:
+        for options, message in invalid_options:
+            reader_options = {"data_key": "data", **options}
+            with pytest.raises(ValueError, match=message):
+                configurable_h5_reader(h5_file, **reader_options)
+
+
+def test_h5_reader_validates_column_shape_and_group_columns(tmp_path):
+    """Reject invalid column metadata and non-dataset column paths."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.ones((2, 2)))
+        h5_file.create_dataset("columns", data=np.array([b"one"]))
+        group = h5_file.create_group("group")
+        group.create_group("columns")
+
+    with h5py.File(h5_path, "r") as h5_file:
+        with pytest.raises(ValueError, match="contains 1 names"):
+            configurable_h5_reader(h5_file, data_key="data", columns_key="columns")
+        with pytest.raises(TypeError, match="columns path"):
+            configurable_h5_reader(
+                h5_file,
+                group_key="group",
+                columns_key="columns",
+                columns_as_datasets=True,
+            )
+
+
+def test_h5_reader_reads_custom_index_names_key(tmp_path):
+    """Use a configured dataset name for generic index metadata."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([[1.0]]))
+        h5_file.create_dataset("columns", data=np.array([b"value"]))
+        h5_file.create_dataset("names", data=np.array([b"index_year"]))
+        h5_file.create_dataset("index_0", data=np.array([2030]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(
+            h5_file,
+            data_key="data",
+            columns_key="columns",
+            index_names_key="names",
+            additional_keys=["index_0"],
+        )
+
+    assert result["solve_year"].tolist() == [2030]
+
+
+def test_h5_reader_skips_missing_additional_dataset(tmp_path):
+    """Ignore optional additional dataset names that are not present."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([1.0]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(h5_file, data_key="data", additional_keys=["missing"])
+
+    assert result == {"data": np.array([1.0])}
+
+
+def test_h5_reader_resolves_dataset_path(tmp_path):
+    """Resolve a dataset addressed by a nested HDF5 path."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        group = h5_file.create_group("values")
+        group.create_dataset("data", data=np.array([1.0]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(h5_file, data_key="values/data")
+
+    assert result["values/data"].tolist() == [1.0]

--- a/tests/test_h5_readers.py
+++ b/tests/test_h5_readers.py
@@ -556,6 +556,13 @@ def test_h5_reader_group_validation_errors():
                 )
             with pytest.raises(ValueError, match="columns_key is required"):
                 configurable_h5_reader(f, group_key="group", columns_as_datasets=True)
+            with pytest.raises(ValueError, match="columns path 'missing/columns' not found"):
+                configurable_h5_reader(
+                    f,
+                    group_key="group",
+                    columns_key="missing/columns",
+                    columns_as_datasets=True,
+                )
     finally:
         tmp_path.unlink()
 
@@ -686,6 +693,108 @@ def test_h5_reader_validates_column_shape_and_group_columns(tmp_path):
             )
 
 
+def test_h5_reader_decodes_or_preserves_column_labels(tmp_path):
+    """Honor decode_bytes for row-oriented column labels."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([[1.0, 2.0]]))
+        h5_file.create_dataset("columns", data=np.array([b"one", b"two"]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        decoded = configurable_h5_reader(h5_file, data_key="data", columns_key="columns")
+        preserved = configurable_h5_reader(
+            h5_file,
+            data_key="data",
+            columns_key="columns",
+            decode_bytes=False,
+        )
+
+    assert set(decoded) == {"one", "two"}
+    assert set(preserved) == {"one", "two"}
+
+
+def test_h5_reader_honors_decode_bytes_for_index_names(tmp_path):
+    """Use byte index labels to resolve datasets when decoding is disabled."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([[1.0]]))
+        h5_file.create_dataset("columns", data=np.array([b"value"]))
+        h5_file.create_dataset("index_names", data=np.array([b"index_year"]))
+        h5_file.create_dataset("index_0", data=np.array([2030]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(
+            h5_file,
+            data_key="data",
+            columns_key="columns",
+            additional_keys=["index_0"],
+            decode_bytes=False,
+        )
+
+    np.testing.assert_array_equal(result["solve_year"], np.array([2030]))
+
+
+def test_h5_reader_supports_nested_column_metadata_path(tmp_path):
+    """Resolve column metadata through a nested HDF5 path."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        group = h5_file.create_group("group")
+        metadata = group.create_group("metadata")
+        metadata.create_dataset("columns", data=np.array([b"Value"]))
+        group.create_dataset("Value", data=np.array([3.0]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(
+            h5_file,
+            group_key="group",
+            columns_key="metadata/columns",
+            columns_as_datasets=True,
+        )
+
+    np.testing.assert_array_equal(result["Value"], np.array([3.0]))
+
+
+def test_h5_reader_handles_scalar_datetime_dataset(tmp_path):
+    """Normalize a scalar datetime dataset before parsing it."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([1.0]))
+        h5_file.create_dataset("time", data=np.bytes_("2024-01-01T00:00:00Z"))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(h5_file, data_key="data", datetime_key="time")
+
+    np.testing.assert_array_equal(
+        result["datetime"], np.array(["2024-01-01T00:00:00"], dtype="datetime64[us]")
+    )
+
+
+@pytest.mark.parametrize("scope_key", [None, "empty"])
+def test_h5_reader_rejects_empty_default_scope(tmp_path, scope_key):
+    """Raise a clear error when default reading has no HDF5 entries."""
+    h5_path = tmp_path / "empty.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        if scope_key is not None:
+            h5_file.create_group(scope_key)
+
+    with h5py.File(h5_path, "r") as h5_file, pytest.raises(ValueError, match="contains no datasets"):
+        configurable_h5_reader(h5_file, group_key=scope_key)
+
+
+def test_h5_reader_reads_non_string_column_metadata(tmp_path):
+    """Read numeric column metadata without calling HDF5 string decoding."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        h5_file.create_dataset("data", data=np.array([[1.0, 2.0]]))
+        h5_file.create_dataset("columns", data=np.array([10, 20]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(h5_file, data_key="data", columns_key="columns")
+
+    np.testing.assert_array_equal(result["10"], np.array([1.0]))
+    np.testing.assert_array_equal(result["20"], np.array([2.0]))
+
+
 def test_h5_reader_reads_custom_index_names_key(tmp_path):
     """Use a configured dataset name for generic index metadata."""
     h5_path = tmp_path / "data.h5"
@@ -705,6 +814,26 @@ def test_h5_reader_reads_custom_index_names_key(tmp_path):
         )
 
     assert result["solve_year"].tolist() == [2030]
+
+
+def test_h5_reader_preserves_columnar_bytes_when_decoding_disabled(tmp_path):
+    """Honor decode_bytes for columnar string datasets and labels."""
+    h5_path = tmp_path / "data.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        group = h5_file.create_group("group")
+        group.create_dataset("columns", data=np.array([b"label"]))
+        group.create_dataset("label", data=np.array([b"gas"]))
+
+    with h5py.File(h5_path, "r") as h5_file:
+        result = configurable_h5_reader(
+            h5_file,
+            group_key="group",
+            columns_key="columns",
+            columns_as_datasets=True,
+            decode_bytes=False,
+        )
+
+    assert result["label"] == [b"gas"]
 
 
 def test_h5_reader_skips_missing_additional_dataset(tmp_path):

--- a/tests/test_h5_readers.py
+++ b/tests/test_h5_readers.py
@@ -584,6 +584,30 @@ def test_h5_reader_columnar_group_reads_scalar_dataset():
         tmp_path.unlink()
 
 
+def test_h5_reader_columnar_group_reads_scalar_string_dataset():
+    """Normalize decoded scalar string column datasets to one-row lists."""
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with h5py.File(str(tmp_path), "w") as f:
+            group = f.create_group("group")
+            group.create_dataset("columns", data=np.array([b"i"]))
+            group.create_dataset("i", data=np.bytes_("gas"))
+
+        with h5py.File(str(tmp_path), "r") as f:
+            result = configurable_h5_reader(
+                f,
+                group_key="group",
+                columns_key="columns",
+                columns_as_datasets=True,
+            )
+
+        assert result["i"] == ["gas"]
+    finally:
+        tmp_path.unlink()
+
+
 def test_h5_reader_rejects_invalid_reader_keys(tmp_path):
     """Reject invalid key types before opening configured datasets."""
     h5_path = tmp_path / "data.h5"
@@ -643,12 +667,16 @@ def test_h5_reader_validates_column_shape_and_group_columns(tmp_path):
     with h5py.File(h5_path, "w") as h5_file:
         h5_file.create_dataset("data", data=np.ones((2, 2)))
         h5_file.create_dataset("columns", data=np.array([b"one"]))
+        h5_file.create_dataset("data_1d", data=np.array([1.0, 2.0]))
+        h5_file.create_dataset("empty_columns", data=np.array([], dtype="S"))
         group = h5_file.create_group("group")
         group.create_group("columns")
 
     with h5py.File(h5_path, "r") as h5_file:
         with pytest.raises(ValueError, match="contains 1 names"):
             configurable_h5_reader(h5_file, data_key="data", columns_key="columns")
+        with pytest.raises(ValueError, match="must contain exactly 1 name"):
+            configurable_h5_reader(h5_file, data_key="data_1d", columns_key="empty_columns")
         with pytest.raises(TypeError, match="columns path"):
             configurable_h5_reader(
                 h5_file,

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -172,6 +172,27 @@ def test_read_data_file_relative_path(reader_example, tmp_path):
     assert result is not None
 
 
+def test_read_optional_data_file_missing_h5_group(reader_example, tmp_path):
+    """Optional HDF5 files return None when their configured group is absent."""
+    import h5py
+
+    from r2x_core import DataFile
+    from r2x_core.datafile import FileInfo, ReaderConfig
+
+    h5_path = tmp_path / "outputs.h5"
+    with h5py.File(h5_path, "w"):
+        pass
+
+    data_file = DataFile(
+        name="fuel_price",
+        fpath=h5_path,
+        info=FileInfo(is_optional=True),
+        reader=ReaderConfig(kwargs={"group_key": "fuel_price"}),
+    )
+
+    assert reader_example.read_data_file(data_file, folder_path=tmp_path) is None
+
+
 def test_read_data_file_h5_group(reader_example, tmp_path):
     """DataFile reader kwargs can select a columnar HDF5 group."""
     import h5py

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -170,3 +170,34 @@ def test_read_data_file_relative_path(reader_example, tmp_path):
     data_file = DataFile(name="test", relative_fpath="data.csv")
     result = reader_example.read_data_file(data_file, folder_path=tmp_path)
     assert result is not None
+
+
+def test_read_data_file_h5_group(reader_example, tmp_path):
+    """DataFile reader kwargs can select a columnar HDF5 group."""
+    import h5py
+    import numpy as np
+
+    from r2x_core import DataFile
+    from r2x_core.datafile import ReaderConfig
+
+    h5_path = tmp_path / "outputs.h5"
+    with h5py.File(h5_path, "w") as h5_file:
+        group = h5_file.create_group("fuel_price")
+        group.create_dataset("columns", data=np.array([b"i", b"Value"]))
+        group.create_dataset("i", data=np.array([b"gas"]))
+        group.create_dataset("Value", data=np.array([3.0]))
+
+    data_file = DataFile(
+        name="fuel_price",
+        fpath=h5_path,
+        reader=ReaderConfig(
+            kwargs={
+                "group_key": "fuel_price",
+                "columns_key": "columns",
+                "columns_as_datasets": True,
+            }
+        ),
+    )
+    result = reader_example.read_data_file(data_file, folder_path=tmp_path).collect()
+
+    assert result.to_dict(as_series=False) == {"i": ["gas"], "Value": [3.0]}


### PR DESCRIPTION
## Summary

- Add configuration-driven support for reading columnar HDF5 groups where each column is stored as its own dataset.
- Add group selection, typed HDF5 dataset resolution, string decoding, index-name resolution, and validation for HDF5 reader options.
- Expand HDF5 and reader integration coverage, bringing the full suite above the 97% project threshold.

## Validation

- `uv run pytest -q`
- `uv run mypy src/r2x_core/h5_readers.py src/r2x_core/file_readers.py`
- `uv run ty check src/`
- `uv run ruff check src/r2x_core/h5_readers.py src/r2x_core/file_readers.py tests/test_h5_readers.py tests/test_reader.py`
- `uv run ruff format --check src/r2x_core/h5_readers.py src/r2x_core/file_readers.py tests/test_h5_readers.py tests/test_reader.py`

Full test result: 719 passed, 97.07% coverage.

## Review

@mcllerena, please review the HDF5 reader behavior, validation, type contracts, and regression coverage.

@copilot, please perform a focused review for correctness, regressions, brittle behavior, and unnecessary complexity.
