### PR TITLE
docs: revamp r2x-core agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,6 @@ prompt_logs/
 
 # Architecture Decision Records (local only)
 docs/adr/
+
+# Agent workflow notes
+PAPERCUTS.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ PLEXOS, SWITCH, Sienna, or other infrasys-backed power-system workflows.
 
 <p align="center">
   <a href="#install">Install</a> ·
+  <a href="#skill-installation">Skills</a> ·
   <a href="#quickstart">Quickstart</a> ·
+  <a href="#r2x-cli">r2x CLI</a> ·
   <a href="#core-concepts">Core concepts</a> ·
   <a href="#documentation">Documentation</a> ·
   <a href="#development">Development</a> ·
@@ -42,6 +44,65 @@ uv add r2x-core
 ```
 
 R2X Core supports Python 3.11, 3.12, and 3.13.
+
+## Skill installation
+
+This repository includes the `r2x-core` agent skill at
+`skills/r2x-core/`. Install it for Pi with either supported skill manager.
+Replace `NatLabRockies/r2x-core` with the canonical published repository if
+this skill is distributed from another fork.
+
+### Skills CLI (`npx skills`)
+
+Install globally:
+
+```console
+npx skills add NatLabRockies/r2x-core --skill r2x-core --agent pi --global --yes
+```
+
+Install for the current project by omitting `--global`:
+
+```console
+npx skills add NatLabRockies/r2x-core --skill r2x-core --agent pi --yes
+```
+
+Update one installed copy:
+
+```console
+npx skills update r2x-core --global --yes
+# For a project-scoped installation, use --project instead of --global.
+```
+
+List installed skills with `npx skills list --global` or `npx skills list`.
+The updater uses source metadata recorded by the installer; manually copied
+skills must be reinstalled before automatic updates can work.
+
+### GitHub CLI (`gh skill`)
+
+Install globally or for the current project:
+
+```console
+gh skill install NatLabRockies/r2x-core r2x-core --agent pi --scope user
+gh skill install NatLabRockies/r2x-core r2x-core --agent pi --scope project
+```
+
+Check for updates, then update one skill or all managed skills:
+
+```console
+gh skill update r2x-core --dry-run
+gh skill update r2x-core
+gh skill update --all
+```
+
+Pin a reproducible release when needed:
+
+```console
+gh skill install NatLabRockies/r2x-core r2x-core@v0.7.0 \
+  --agent pi --scope user
+```
+
+Edit the repository copy under `skills/r2x-core/` when contributing changes.
+Do not patch an installed copy and expect those changes to flow back here.
 
 ## Quickstart
 
@@ -105,6 +166,88 @@ result = plugin.run()
 
 print(result.system.name)
 ```
+
+## r2x CLI
+
+The Rust `r2x` CLI is the recommended orchestration layer for installed
+r2x-core plugins. It installs plugin packages, discovers `r2x_plugin` and
+`r2x.transforms` entry points, refreshes plugin metadata, and runs direct
+plugins or YAML pipelines. The binary is maintained in the
+[`r2x-cli`](https://github.com/NatLabRockies/r2x-cli) repository.
+
+Install the latest release on macOS/Linux:
+
+```console
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/NatLabRockies/r2x-cli/releases/latest/download/r2x-installer.sh | sh
+```
+
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/NatLabRockies/r2x-cli/releases/latest/download/r2x-installer.ps1 | iex"
+```
+
+Verify the binary and its command surface:
+
+```console
+r2x --version
+r2x --help
+```
+
+The published binary requires Python shared libraries at runtime. If it
+reports missing `libpython`, install a supported shared Python with
+`uv python install 3.12`. Use the published release installers or binaries
+only; do not build `r2x` from source as part of the r2x-core workflow.
+
+### Install and discover an r2x-core plugin
+
+```console
+r2x install r2x-reeds
+r2x list
+r2x sync
+r2x run plugin
+```
+
+For a local plugin package under development, run the command from that
+plugin's checkout. `r2x-core` itself is a framework package and does not expose
+an installable plugin entry point:
+
+```console
+cd /path/to/my-translator
+r2x install -e .
+r2x sync
+r2x list
+```
+
+Check a plugin's generated public CLI contract before running it:
+
+```console
+r2x run plugin r2x-reeds.reeds-parser --show-help
+```
+
+### Validate and run a pipeline
+
+Use the CLI's validation stages before executing data translation:
+
+```console
+r2x init
+r2x run pipeline.yaml --list
+r2x run pipeline.yaml --print reeds-to-sienna
+r2x run pipeline.yaml reeds-to-sienna --dry-run
+r2x run pipeline.yaml reeds-to-sienna --output output/system.json
+```
+
+Use `--list` to validate the pipeline name, `--print` to inspect resolved
+configuration, and `--dry-run` to verify ordering without translating data. Keep
+plugin diagnostics on stderr and translation artifacts on stdout or a durable
+`--output` path. Use `set -o pipefail` for streamed plugin pipelines.
+
+The CLI's `-q`, `-v`, and `-vv` flags control CLI verbosity. Use
+`--log-python` or `r2x log set log-python true` when Python/Loguru diagnostics
+must be shown. See the skill's [r2x CLI reference](skills/r2x-core/references/R2X_CLI.md)
+for discovery, direct execution, durable `-o`/`-i` boundaries, pipeline
+validation, and failure triage.
 
 ### Create a function transform
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ R2X Core supports Python 3.11, 3.12, and 3.13.
 
 This repository includes the `r2x-core` agent skill at
 `skills/r2x-core/`. Install it for Pi with either supported skill manager.
-Replace `NatLabRockies/r2x-core` with the canonical published repository if
-this skill is distributed from another fork.
+The commands below use the canonical repository, `NatLabRockies/r2x-core`.
 
 ### Skills CLI (`npx skills`)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,19 +34,19 @@ html_theme = "furo"
 html_title = "r2x-core"
 html_theme_options = {
     "navigation_with_keys": True,
-    "source_repository": "https://github.com/NREL/r2x-core",
+    "source_repository": "https://github.com/NatLabRockies/r2x-core",
     "source_branch": "main",
     "source_directory": "docs/source/",
     "top_of_page_buttons": ["view", "edit"],
     "announcement": """
         <strong>🎉 R2X Core v1.0.0 is now available!</strong>
         This is our first Long-Term Support (LTS) release.
-        <a href="https://github.com/NREL/r2x-core/releases/tag/v0.1.0" target="_blank">View release notes</a>
+        <a href="https://github.com/NatLabRockies/r2x-core/releases/tag/v0.1.0" target="_blank">View release notes</a>
     """,
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/NREL/r2x-core",
+            "url": "https://github.com/NatLabRockies/r2x-core",
             "html": """
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -10,7 +10,7 @@ Set up a development environment for contributing to R2X Core:
 
 ```console
 # Clone the repository
-git clone https://github.com/NREL/r2x-core.git
+git clone https://github.com/NatLabRockies/r2x-core.git
 cd r2x-core
 
 # Install with development dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/NREL/r2x-core"
-Documentation = "https://nrel.github.io/r2x-core/"
-Repository = "https://github.com/NREL/r2x-core"
-Issues = "https://github.com/NREL/r2x-core/issues"
-Changelog = "https://nrel.github.io/r2x-core/CHANGELOG.html"
+Homepage = "https://github.com/NatLabRockies/r2x-core"
+Documentation = "https://natlabrockies.github.io/r2x-core/"
+Repository = "https://github.com/NatLabRockies/r2x-core"
+Issues = "https://github.com/NatLabRockies/r2x-core/issues"
+Changelog = "https://natlabrockies.github.io/r2x-core/CHANGELOG.html"
 
 [dependency-groups]
 dev = [

--- a/skills/r2x-core/SKILL.md
+++ b/skills/r2x-core/SKILL.md
@@ -1,153 +1,185 @@
 ---
 name: r2x-core
-description: |
-  Build and maintain r2x-core translators across plugin lifecycle, rule
-  mapping, DataStore ingestion, units, and upgrades. Use when tasks mention
-  r2x-core plugins/rules/datastore/unit-system/versioning, translator
-  discovery, model conversion pipelines, schema migrations, or function
-  transforms built on infrasys System/Component models.
-license: BSD-3-Clause
-metadata:
-  author: r2x-core team
-  version: "0.2.0"
-  category: power-system-translation
-  companion_skills:
-    - name: infrasys
-      source: pesap/agents
-      use_when: Pure System/Component modeling, serialization, time series, supplemental attributes, or component graph behavior.
-      fallback: Use infrasys docs/source.
-    - name: python-developer
-      source: pesap/agents
-      use_when: Python typing, pytest, packaging, or implementation mechanics around r2x-core code.
-      fallback: Use project Python standards and local tests.
-    - name: data-model
-      source: pesap/agents
-      use_when: PluginConfig, Pydantic schemas, or typed configuration contracts.
-      fallback: Use Pydantic v2 docs and existing config models.
+description: >
+  Build, debug, review, and extend r2x-core translators and their public Python
+  APIs, including Plugin, PluginConfig, PluginContext, exposed transforms,
+  Rule and RuleFilter translation, DataFile/DataStore/DataReader ingestion,
+  HDF5 readers, unit-aware components, persistence, and upgrades. Use when a
+  task mentions r2x-core, model translation, parser or exporter plugins, rule
+  mappings, DataStore configuration, per-unit behavior, or r2x-core schema
+  upgrades. Do not use for standalone Python guidance or foundational infrasys
+  modeling with no r2x-core surface.
 ---
 
 # r2x-core
 
-Operational skill for r2x-core, the application translation layer on top of
-infrasys `System` / `Component` primitives.
+Operational guidance for the r2x-core translation layer on top of infrasys
+`System` and `Component` models. Treat the public API examples in
+[QUICKREF.md](./references/QUICKREF.md) as the first stop for every task. Load
+only the focused reference needed for the task.
 
-## Use when
+## Mental model
 
-- Authoring, debugging, or extending an r2x-core `Plugin` or translator.
-- Wiring `PluginConfig`, `PluginContext`, `@expose_plugin`, or entry points.
-- Designing or auditing declarative `Rule` mappings, `RuleFilter`
-  composition, or rule executor behavior.
-- Configuring a `DataStore`, `DataFile`, readers, processors, or HDF5 input.
-- Working with `Ok` / `Err` / `Result`, `RuleResult`, or `TranslationResult`.
-- Handling `HasUnits`, `HasPerUnit`, `UnitSystem`, or per-unit conversions.
-- Defining `UpgradeStep` chains, version readers, or dataset/schema upgrades.
-- Building r2x-core function transforms over infrasys systems.
-
-## Avoid when
-
-- The task is only about infrasys `System` / `Component` internals with no
-  r2x-core translator surface.
-- The task is generic Python packaging, CLI, docs, or testing with no
-  r2x-core surface area.
-- The task is purely an end-user model semantics question, such as PLEXOS XML
-  details, without touching the r2x-core translator boundary.
-
-## Companion skills
-
-Some tasks are better handled by a companion skill. Use a companion skill when
-it is available; otherwise stay in this skill and verify from the companion
-project's docs/source. The same companion list is also declared in frontmatter
-metadata for runtimes that can inspect skill metadata.
-
-| Task center                                                                                                            | Preferred companion | Fallback when unavailable                       |
-| ---------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------- |
-| Pure `System` / `Component` modeling, serialization, time series, supplemental attributes, or component graph behavior | `infrasys`          | Use infrasys docs/source                        |
-| Python typing, pytest, packaging, or implementation mechanics around r2x-core code                                     | `python-developer`  | Use project Python standards and local tests    |
-| `PluginConfig`, Pydantic schemas, or typed configuration contracts                                                     | `data-model`        | Use Pydantic v2 docs and existing config models |
-
-If the runtime supports GitHub skill installation and the user/runtime permits
-installing external skills, install/select missing companion skills from the
-shared skills repository:
-
-```bash
-gh skill install pesap/agents
-# choose the companion skill named above
+```text
+input files -> DataStore/DataReader -> PluginContext -> Plugin lifecycle
+                                      -> Rule executor -> target System
+                                      -> persistence or export
 ```
 
-If both this skill and a companion apply, use this skill for the r2x-core
-translator boundary and the companion skill/docs for the underlying concern.
+- `PluginConfig` owns typed configuration and configuration-asset paths.
+- `PluginContext` owns shared mutable execution state: config, stores, systems,
+  rules, metadata, and version settings.
+- `Plugin` provides optional lifecycle hooks. Hooks return `rust_ok` results;
+  `Plugin.run()` updates the context and returns the context.
+- `Rule` declares source-to-target component construction. The executor reads
+  systems from the context and writes target components to the target system.
+- `DataFile` describes one input. `DataStore` groups file specifications and
+  `DataReader` performs the read and processing pipeline.
+- Domain `System` / `Component` semantics remain owned by infrasys and the
+  component package, not by this skill.
 
-## Read order
+## Public API routing
 
-Start here, then load only the focused reference needed for the task:
+Read [QUICKREF.md](./references/QUICKREF.md) first. Then route by task center:
 
-1. Fast API map: [references/QUICKREF.md](./references/QUICKREF.md)
-2. Cross-cutting contracts: [references/REFERENCE.md](./references/REFERENCE.md)
-3. API/source validation protocol: [references/DISCOVERY.md](./references/DISCOVERY.md)
-4. Plugin lifecycle: [references/PLUGINS.md](./references/PLUGINS.md)
-5. Rules: [references/RULES.md](./references/RULES.md)
-6. Data ingestion: [references/DATA_STORE.md](./references/DATA_STORE.md)
-7. Units: [references/UNITS.md](./references/UNITS.md)
-8. Versioning/upgrades: [references/VERSIONING_UPGRADES.md](./references/VERSIONING_UPGRADES.md)
-9. Shared utilities: [references/UTILITIES.md](./references/UTILITIES.md)
-10. Trigger checks: [evals/TRIGGER_PROMPTS.md](./evals/TRIGGER_PROMPTS.md)
+| Task center                                                 | Read                                                          |
+| ----------------------------------------------------------- | ------------------------------------------------------------- |
+| Plugin class, config, context, exposure, lifecycle          | [PLUGINS.md](./references/PLUGINS.md)                         |
+| Rule declarations, filters, getters, execution              | [RULES.md](./references/RULES.md)                             |
+| Files, readers, processors, HDF5, datastore                 | [DATA_STORE.md](./references/DATA_STORE.md)                   |
+| `Annotated` unit fields and display modes                   | [UNITS.md](./references/UNITS.md)                             |
+| Version strategies, `UpgradeStep`, coordinator              | [VERSIONING_UPGRADES.md](./references/VERSIONING_UPGRADES.md) |
+| Component extraction, creation, export, time-series helpers | [UTILITIES.md](./references/UTILITIES.md)                     |
+| Source/signature verification or docs drift                 | [DISCOVERY.md](./references/DISCOVERY.md)                     |
+| Logging levels, sinks, structured context, or diagnostics   | [LOGGING.md](./references/LOGGING.md)                         |
+| `r2x` CLI orchestration and plugin validation               | [R2X_CLI.md](./references/R2X_CLI.md)                         |
+| Cross-cutting design and failure contracts                  | [REFERENCE.md](./references/REFERENCE.md)                     |
 
-## Authoritative contracts
+## Public API rules
 
-- `Plugin.run(*, ctx: PluginContext | None = None) -> PluginContext` and
-  raises `PluginError` on hook `Err`.
-- `apply_rules_to_context(context: PluginContext) -> TranslationResult`.
-- `apply_single_rule(rule: Rule, *, context: PluginContext) -> Result[RuleApplicationStats, ValueError]`.
-- `DataStore.add_data(data_files: Sequence[DataFile], *, overwrite: bool = False) -> None`.
-- `run_upgrade_step(data, *, step: UpgradeStep, upgrader_context=None) -> Result[Any, str]`.
+Use these rules to prevent the unreliable call patterns this skill is intended
+to eliminate:
 
-## Do
+1. Import from `r2x_core` when the symbol is in `src/r2x_core/__init__.py`.
+   Do not invent a second abstraction or use private internals to avoid the
+   public API.
+2. Verify unfamiliar signatures against root exports, defining source, nearby
+   tests, and project docs. Source and tests outrank stale documentation.
+3. `Plugin.run()` returns `PluginContext`, not `Result`. It raises
+   `PluginError` when a hook returns `Err`.
+4. `apply_rules_to_context(context)` reads rules from `context.rules`; it does
+   not accept a second rules argument. `apply_single_rule(rule, *, context=...)`
+   takes the rule first and returns rule-application statistics in a `Result`.
+5. `DataFile` uses `info`, `reader`, and `proc_spec`. Its path source is exactly
+   one of `fpath`, `relative_fpath`, or `glob`. `DataStore.add_data(...)` takes a
+   sequence of files.
+6. `VersionReader` is a protocol. `UpgradeStep` uses `target_version` with
+   optional `min_version` and `max_version`; it does not use
+   `from_version`/`to_version` constructor fields.
+7. Use Pydantic v2 `PluginConfig` subclasses and explicit typed fields. Use
+   `Annotated[..., Field(...)]` for new modeled fields and
+   `Field(default_factory=...)` for mutable defaults.
+8. Use `Ok` / `Err` at recoverable boundaries. Branch on results explicitly; do
+   not unwrap live results, catch `Exception` broadly, or hide failures behind
+   `None`.
+9. Prefer domain models, protocols, named structured returns, and keyword-only
+   configuration over loose dictionaries, `object`, casual casts, and long
+   positional tuples.
+10. Use the repository logging policy. Loguru is disabled by default; every
+    application built on r2x-core should disable its own package namespace at
+    import time and enable it explicitly at the application boundary. Use
+    `setup_logging(...)` only there, select levels by operational meaning, and
+    keep diagnostics structured and non-sensitive.
+11. Test public behavior. Add a regression test for a bug, reuse repository
+    fixtures, and round-trip persistence changes through serialization.
 
-- Inspect installed source when exact signatures matter, especially after
-  r2x-core upgrades. Use `references/DISCOVERY.md`.
-- Keep configuration typed with `PluginConfig` subclasses, not loose dicts.
-- Implement only lifecycle hooks the translator actually needs.
-- Return `Ok(value)` / `Err(error)` from plugin hooks and upgrade helpers.
-- Put file-reading concerns at the `DataFile` / `DataStore` boundary.
-- Prefer declarative `Rule` + `RuleFilter` mapping over ad-hoc translator
-  branches when the mapping is data-shaped.
-- Round-trip produced systems through infrasys serialization when persistence
-  is part of the task.
-- Report which reference docs and source modules were decisive.
+## Minimal public examples
 
-## Don't
+A class plugin is constructed from a typed context and returns that context:
 
-- Do not call `apply_rules_to_context(context, rules)`. Attach rules to the
-  context, then call `apply_rules_to_context(context)`.
-- Do not call `apply_single_rule(context, rule)`. Use
-  `apply_single_rule(rule, context=context)`.
-- Do not treat `plugin.run()` as a `Result`; catch `PluginError` at the
-  orchestration boundary if needed.
-- Do not use `RuleFilter(lambda ...)`; use declarative field/op/value filters.
-- Do not pass `DataFile(reader_config=..., processing=..., file_info=...)`;
-  use `reader=...`, `proc_spec=...`, and `info=...` for current APIs.
-- Do not use `VersionReader(strategy=...)`; implement the protocol.
-- Do not define `UpgradeStep(from_version=..., to_version=...)`; use
-  `target_version` with optional `min_version` / `max_version`.
-- Do not add compatibility import fallbacks around `r2x_core` APIs in repo
-  code unless the user explicitly asks for multi-version support.
+```python
+from pydantic import Field
+from rust_ok import Ok, Result
+
+from r2x_core import Plugin, PluginConfig, PluginContext, System
+
+
+class BuildConfig(PluginConfig):
+    name: str = Field(default="demo", min_length=1, description="System name")
+
+
+class BuildPlugin(Plugin[BuildConfig]):
+    def on_build(self) -> Result[System, str]:
+        return Ok(System(name=self.config.name))
+
+
+context = PluginContext(config=BuildConfig(name="western_grid"))
+result_context = BuildPlugin.from_context(context).run()
+assert result_context.system is not None
+assert result_context.system.name == "western_grid"
+```
+
+A function transform is called explicitly. `@expose_plugin` marks the function;
+it does not wrap, instantiate, inject, or execute it:
+
+```python
+from pydantic import Field
+from rust_ok import Ok, Result
+
+from r2x_core import PluginConfig, System, expose_plugin
+
+
+class RenameConfig(PluginConfig):
+    suffix: str = Field(default="_v2", description="Suffix to append")
+
+
+@expose_plugin
+def rename_system(system: System, config: RenameConfig) -> Result[System, str]:
+    system.name = f"{system.name}{config.suffix}"
+    return Ok(system)
+```
 
 ## Workflow
 
-1. Classify the surface: plugin, rules, datastore, units, versioning,
-   function transforms, or infrasys boundary.
-2. Load the matching reference document from `references/`.
-3. Verify exact APIs from installed/project source when behavior is uncertain.
-4. Make the smallest change that preserves public translator contracts.
-5. Validate with targeted tests, source inspection, or round-trip checks.
-6. In the handoff, include touched surface, APIs validated, docs consulted,
-   result/error behavior, and any public symbols changed.
+1. **Classify the surface:** plugin, rules, data, units, persistence, or
+   upgrades. Keep pure infrasys work separate.
+2. **Inspect first:** read repository instructions, `pyproject.toml`, defining
+   source modules, adjacent tests, and relevant docs. Reproduce failures when
+   practical.
+3. **Confirm the contract:** inspect root exports and exact signatures. If the
+   installed package differs from the checkout, state which one is targeted.
+4. **Implement a small vertical slice:** keep configuration, domain models,
+   translator logic, and boundary serialization separate. Reuse existing APIs.
+5. **Validate narrowly, then expand:** run focused tests first, then the
+   repository's `just` target or required `prek`/pytest checks. Round-trip real
+   systems when persistence is involved.
+6. **Report evidence:** include public behaviors changed, exact commands and
+   outcomes, assumptions, and remaining risks.
 
-## Output expectations
+For logging changes, load [LOGGING.md](./references/LOGGING.md) and validate
+namespace disable/enable behavior, level filtering, sink behavior, structured
+fields, and exception output.
 
-- Surface touched: plugin / rules / store / units / versioning / transform.
-- Exact APIs inspected or called for validation.
-- Reference files consulted and why.
-- Result-type usage and error propagation decisions.
-- Persistence, upgrade, or round-trip checks performed when relevant.
-- Public symbols or entry points changed, including `__all__` when applicable.
+## Validation helpers
+
+Run these from the r2x-core checkout when appropriate:
+
+```bash
+uv run python skills/r2x-core/tools/check_api_symbols.py
+uv run python skills/r2x-core/tools/check_api_symbols.py --repo src/r2x_core
+uv run python skills/r2x-core/tools/inspect_plugins.py --group r2x_plugin
+uv run python skills/r2x-core/tools/check_data_store.py <data-root> --list-unknown
+```
+
+The API probe checks symbol presence, not semantics. The plugin probe checks
+installed entry points and import failures. The datastore probe classifies files;
+it cannot prove reader options or schema correctness.
+
+## Handoff
+
+- **Surface:** plugin, rules, data, units, persistence, upgrades, transform,
+  or logging.
+- **Contract:** public symbols and return/error behavior involved.
+- **Changes:** files and observable behavior.
+- **Validation:** exact commands and results.
+- **Risks:** source/docs mismatches, untested integrations, or follow-up work.

--- a/skills/r2x-core/SKILL.md
+++ b/skills/r2x-core/SKILL.md
@@ -171,9 +171,13 @@ uv run python skills/r2x-core/tools/inspect_plugins.py --group r2x_plugin
 uv run python skills/r2x-core/tools/check_data_store.py <data-root> --list-unknown
 ```
 
-The API probe checks symbol presence, not semantics. The plugin probe checks
-installed entry points and import failures. The datastore probe classifies files;
-it cannot prove reader options or schema correctness.
+The API probe checks symbol presence, not semantics. The plugin probe inspects
+entry points in the active Python environment, not the repository source tree.
+This r2x-core checkout does not define an `r2x_plugin` entry point, so running the
+probe here without an installed translator should report no entries. Run it in
+the environment that contains the plugin package you want to inspect; otherwise
+that result is expected and not a discovery failure. The datastore probe
+classifies files; it cannot prove reader options or schema correctness.
 
 ## Handoff
 

--- a/skills/r2x-core/evals/TRIGGER_PROMPTS.md
+++ b/skills/r2x-core/evals/TRIGGER_PROMPTS.md
@@ -1,49 +1,39 @@
-# r2x-core Skill Trigger Examples
+# r2x-core trigger examples
 
-Use these prompts to validate when this skill should activate.
+Use these prompts to tune activation and routing. They are not a substitute for
+reading the focused reference.
 
 ## Should trigger
 
-1. "Add a new translator plugin for ReEDS that loads CSVs from a data
-   directory and produces an infrasys `System`."
-2. "My `Plugin.on_translate` is raising instead of returning `Err`. Refactor
-   the lifecycle to use `Result` end to end."
-3. "Register `MyTranslator` so `r2x_plugin` entry-point discovery picks it up
-   without a manual import."
-4. "Define a `Rule` mapping `SourceGenerator -> Generator` with a
-   `RuleFilter` that excludes retired units, then wire it into the executor."
-5. "Configure a `DataStore` that reads `gen.csv`, `load.parquet`, and
-   `regions.h5` with the right `ReaderConfig` layout kwargs per file."
-6. "Convert a model that exposes natural-unit values into the per-unit
-   system using `HasPerUnit`, with `UnitSystem.SYSTEM_BASE` for display."
-7. "Build an `UpgradeStep` chain to migrate datasets from v1 to v2 using
-   `SemanticVersioningStrategy` and `VersionReader`."
-8. "Inspect which plugins are discoverable in the current environment and
-   show their `PluginConfig` fields and implemented hooks."
+1. "Build a typed r2x-core translator plugin that loads CSVs and builds a
+   System."
+2. "Why does `Plugin.run()` fail even though my hook returns `Err`?"
+3. "Show the public API call shape for `apply_single_rule` and fix my caller."
+4. "Map source generators to target units with a versioned Rule and filter."
+5. "Configure DataFile and DataStore for CSV, JSON, Parquet, and HDF5 inputs."
+6. "Debug an HDF5 reader returning generic columns instead of solve_year."
+7. "Add an Annotated per-unit field and test natural-unit input."
+8. "Add an upgrade step for an old file mapping and verify idempotency."
+9. "Check which r2x-core plugins are discoverable in the active environment."
+10. "Review this r2x-core change for public API, Result, typing, and regression
+    risks."
 
-## Near-miss (should NOT trigger)
+## Should not trigger
 
-1. "Help me design a generic Python package without any r2x-core surface
-   area." (use general Python guidance)
-2. "Pick a UI framework for a power system dashboard." (out of scope)
-3. "Explain the PLEXOS XML schema in detail." (model-specific, not r2x-core)
-4. "Pure infrasys `System` introspection question with no r2x-core plugin,
-   rule, store, units, or versioning context." (use the `infrasys` skill)
+1. "Design a generic Pydantic model unrelated to r2x-core." (use data-model)
+2. "Inspect an infrasys System and attach time series without translation."
+   (use infrasys)
+3. "Write a standalone Python CLI." (use Python/CLI guidance)
+4. "Explain PLEXOS XML semantics without framework code." (use domain guidance)
+5. "Review an unrelated pull request." (use review guidance)
+6. "Commit the current changes." (use repository/forge workflow)
 
-## Borderline prompts (trigger + integrated reference)
+## Borderline routing
 
-1. "Migrate an old DataStore JSON layout to the new schema."
-   - Trigger this skill, then use `VERSIONING_UPGRADES.md` and
-     `DATA_STORE.md`.
-2. "Plugin entry point is not discovered after install."
-   - Trigger this skill, then use `PLUGINS.md` (registration / exposure
-     section) and inspect `importlib.metadata.entry_points(group="r2x_plugin")`.
-3. "Rule mapping silently skips a component class."
-   - Trigger this skill, then use `RULES.md` (filter and dependency
-     sections) and `REFERENCE.md` (executor contract).
-4. "HDF5 reader returns the wrong shape for a time-indexed dataset."
-   - Trigger this skill, then use `DATA_STORE.md` (HDF5 `ReaderConfig`
-     layout kwargs section). Validate with `DataStore.list_data()` and targeted `read_data(...)` checks.
-5. "Per-unit conversion mismatches between two plugins."
-   - Trigger this skill, then use `UNITS.md` and confirm both plugins use
-     the same `set_unit_system(...)` configuration.
+- A translator component schema belongs to the component package or infrasys;
+  use this skill only for the r2x-core plugin/rule/store boundary.
+- A `System.from_json` migration belongs to infrasys when it changes the
+  foundational serialized schema; use this skill for r2x-core file/config
+  upgrades around that boundary.
+- A generic reader belongs to Python guidance; use this skill when it extends
+  `DataReader`, `DataFile`, `DataStore`, or HDF5 handling.

--- a/skills/r2x-core/evals/evals.json
+++ b/skills/r2x-core/evals/evals.json
@@ -1,77 +1,73 @@
 {
-  "skill_name": "r2x-core",
   "evals": [
     {
-      "id": "public-plugin-api",
-      "prompt": "Build a small r2x-core plugin that creates a System.",
-      "expected_output": "A typed PluginConfig, PluginContext, Plugin subclass, exact run() usage, and focused validation.",
       "assertions": [
         "The response inspects source or tests before relying on signatures",
         "The example uses Plugin.from_context(PluginContext(...)).run()",
         "The response states that run() returns PluginContext and hook failures become PluginError",
         "The config is a typed PluginConfig subclass"
-      ]
+      ],
+      "expected_output": "A typed PluginConfig, PluginContext, Plugin subclass, exact run() usage, and focused validation.",
+      "id": "public-plugin-api",
+      "prompt": "Build a small r2x-core plugin that creates a System."
     },
     {
-      "id": "public-rule-api",
-      "prompt": "Fix this caller that passes a list of rules and raw components to apply_single_rule.",
-      "expected_output": "A correction using PluginContext and the actual apply_single_rule(rule, *, context=...) contract.",
       "assertions": [
         "The response inspects rules_executor.py and nearby tests",
         "The response uses field_map in target-to-source direction",
         "The response distinguishes RuleResult from RuleApplicationStats",
         "The response does not invent a second positional context/rules argument"
-      ]
+      ],
+      "expected_output": "A correction using PluginContext and the actual apply_single_rule(rule, *, context=...) contract.",
+      "id": "public-rule-api",
+      "prompt": "Fix this caller that passes a list of rules and raw components to apply_single_rule."
     },
     {
-      "id": "data-api",
-      "prompt": "Configure r2x-core to read an HDF5 file with named columns and timestamps.",
-      "expected_output": "A DataFile with a path source and ReaderConfig(kwargs=...) using current HDF5 reader options.",
       "assertions": [
         "The response verifies current DataFile field names",
         "The HDF5 settings are placed in reader.kwargs",
         "The response does not invent an H5Format configuration model",
         "The response includes a reader or datastore validation path"
-      ]
+      ],
+      "expected_output": "A DataFile with a path source and ReaderConfig(kwargs=...) using current HDF5 reader options.",
+      "id": "data-api",
+      "prompt": "Configure r2x-core to read an HDF5 file with named columns and timestamps."
     },
     {
-      "id": "units-api",
-      "prompt": "Add a per-unit generator field and test natural-unit input.",
-      "expected_output": "Annotated fields with Unit, HasPerUnit, a base field, and focused behavior tests.",
       "assertions": [
         "The response uses Annotated[..., Unit(...)]",
         "The per-unit field names its base",
         "The response distinguishes HasPerUnit from HasUnits",
         "The response restores global unit display state in tests"
-      ]
+      ],
+      "expected_output": "Annotated fields with Unit, HasPerUnit, a base field, and focused behavior tests.",
+      "id": "units-api",
+      "prompt": "Add a per-unit generator field and test natural-unit input."
     },
     {
-      "id": "upgrade-api",
-      "prompt": "Add an r2x-core file upgrade from 1.x to 2.0.",
-      "expected_output": "An idempotent UpgradeStep and exact run_upgrade_step(data, step=step) handling.",
       "assertions": [
         "The response checks current UpgradeStep fields",
         "The step does not receive a nonexistent versioning_strategy constructor argument",
         "The response branches on Result failure",
         "The response tests idempotency or a failure path"
-      ]
+      ],
+      "expected_output": "An idempotent UpgradeStep and exact run_upgrade_step(data, step=step) handling.",
+      "id": "upgrade-api",
+      "prompt": "Add an r2x-core file upgrade from 1.x to 2.0."
     },
     {
-      "id": "logging-policy",
-      "prompt": "Add logging to an r2x-core plugin and decide which Loguru levels to use.",
-      "expected_output": "A logging design that follows the repository's disabled-by-default namespace setup, chooses levels by operational meaning, and shows application enablement.",
       "assertions": [
         "The response inspects src/r2x_core/logger.py and tests/test_logger.py",
         "The response explains TRACE, DEBUG, INFO, WARNING, ERROR, and CRITICAL usage",
         "The response tells consuming applications to disable their own namespace in __init__.py",
         "The response shows logger.enable for the application and setup_logging for r2x_core",
         "The response avoids print debugging, secrets, and unbounded payload logging"
-      ]
+      ],
+      "expected_output": "A logging design that follows the repository's disabled-by-default namespace setup, chooses levels by operational meaning, and shows application enablement.",
+      "id": "logging-policy",
+      "prompt": "Add logging to an r2x-core plugin and decide which Loguru levels to use."
     },
     {
-      "id": "r2x-cli-workflow",
-      "prompt": "Make this r2x-core plugin discoverable and validate it through the r2x CLI.",
-      "expected_output": "Entry-point validation, r2x sync/list/show-help checks, dry-run pipeline validation, and a bounded real execution with separate stdout/stderr handling.",
       "assertions": [
         "The response reads the r2x CLI integration reference or current CLI source",
         "The response uses published r2x binaries or release installers and does not suggest building the CLI from source",
@@ -79,17 +75,21 @@
         "The response uses r2x sync and r2x list before execution",
         "The response uses --show-help, --list, --print, and --dry-run as validation stages",
         "The response checks durable output or pipefail behavior"
-      ]
+      ],
+      "expected_output": "Entry-point validation, r2x sync/list/show-help checks, dry-run pipeline validation, and a bounded real execution with separate stdout/stderr handling.",
+      "id": "r2x-cli-workflow",
+      "prompt": "Make this r2x-core plugin discoverable and validate it through the r2x CLI."
     },
     {
-      "id": "source-of-truth",
-      "prompt": "The r2x-core docs show a different signature from my checkout. Which usage is correct?",
-      "expected_output": "A source-and-test-backed answer that identifies the target package version and avoids compatibility fallbacks.",
       "assertions": [
         "The response checks __init__.py, defining source, tests, and package metadata",
         "The response distinguishes source checkout from installed package",
         "The response does not conceal the mismatch with try/except imports"
-      ]
+      ],
+      "expected_output": "A source-and-test-backed answer that identifies the target package version and avoids compatibility fallbacks.",
+      "id": "source-of-truth",
+      "prompt": "The r2x-core docs show a different signature from my checkout. Which usage is correct?"
     }
-  ]
+  ],
+  "skill_name": "r2x-core"
 }

--- a/skills/r2x-core/evals/evals.json
+++ b/skills/r2x-core/evals/evals.json
@@ -1,0 +1,95 @@
+{
+  "skill_name": "r2x-core",
+  "evals": [
+    {
+      "id": "public-plugin-api",
+      "prompt": "Build a small r2x-core plugin that creates a System.",
+      "expected_output": "A typed PluginConfig, PluginContext, Plugin subclass, exact run() usage, and focused validation.",
+      "assertions": [
+        "The response inspects source or tests before relying on signatures",
+        "The example uses Plugin.from_context(PluginContext(...)).run()",
+        "The response states that run() returns PluginContext and hook failures become PluginError",
+        "The config is a typed PluginConfig subclass"
+      ]
+    },
+    {
+      "id": "public-rule-api",
+      "prompt": "Fix this caller that passes a list of rules and raw components to apply_single_rule.",
+      "expected_output": "A correction using PluginContext and the actual apply_single_rule(rule, *, context=...) contract.",
+      "assertions": [
+        "The response inspects rules_executor.py and nearby tests",
+        "The response uses field_map in target-to-source direction",
+        "The response distinguishes RuleResult from RuleApplicationStats",
+        "The response does not invent a second positional context/rules argument"
+      ]
+    },
+    {
+      "id": "data-api",
+      "prompt": "Configure r2x-core to read an HDF5 file with named columns and timestamps.",
+      "expected_output": "A DataFile with a path source and ReaderConfig(kwargs=...) using current HDF5 reader options.",
+      "assertions": [
+        "The response verifies current DataFile field names",
+        "The HDF5 settings are placed in reader.kwargs",
+        "The response does not invent an H5Format configuration model",
+        "The response includes a reader or datastore validation path"
+      ]
+    },
+    {
+      "id": "units-api",
+      "prompt": "Add a per-unit generator field and test natural-unit input.",
+      "expected_output": "Annotated fields with Unit, HasPerUnit, a base field, and focused behavior tests.",
+      "assertions": [
+        "The response uses Annotated[..., Unit(...)]",
+        "The per-unit field names its base",
+        "The response distinguishes HasPerUnit from HasUnits",
+        "The response restores global unit display state in tests"
+      ]
+    },
+    {
+      "id": "upgrade-api",
+      "prompt": "Add an r2x-core file upgrade from 1.x to 2.0.",
+      "expected_output": "An idempotent UpgradeStep and exact run_upgrade_step(data, step=step) handling.",
+      "assertions": [
+        "The response checks current UpgradeStep fields",
+        "The step does not receive a nonexistent versioning_strategy constructor argument",
+        "The response branches on Result failure",
+        "The response tests idempotency or a failure path"
+      ]
+    },
+    {
+      "id": "logging-policy",
+      "prompt": "Add logging to an r2x-core plugin and decide which Loguru levels to use.",
+      "expected_output": "A logging design that follows the repository's disabled-by-default namespace setup, chooses levels by operational meaning, and shows application enablement.",
+      "assertions": [
+        "The response inspects src/r2x_core/logger.py and tests/test_logger.py",
+        "The response explains TRACE, DEBUG, INFO, WARNING, ERROR, and CRITICAL usage",
+        "The response tells consuming applications to disable their own namespace in __init__.py",
+        "The response shows logger.enable for the application and setup_logging for r2x_core",
+        "The response avoids print debugging, secrets, and unbounded payload logging"
+      ]
+    },
+    {
+      "id": "r2x-cli-workflow",
+      "prompt": "Make this r2x-core plugin discoverable and validate it through the r2x CLI.",
+      "expected_output": "Entry-point validation, r2x sync/list/show-help checks, dry-run pipeline validation, and a bounded real execution with separate stdout/stderr handling.",
+      "assertions": [
+        "The response reads the r2x CLI integration reference or current CLI source",
+        "The response uses published r2x binaries or release installers and does not suggest building the CLI from source",
+        "The response distinguishes r2x_plugin from r2x.transforms",
+        "The response uses r2x sync and r2x list before execution",
+        "The response uses --show-help, --list, --print, and --dry-run as validation stages",
+        "The response checks durable output or pipefail behavior"
+      ]
+    },
+    {
+      "id": "source-of-truth",
+      "prompt": "The r2x-core docs show a different signature from my checkout. Which usage is correct?",
+      "expected_output": "A source-and-test-backed answer that identifies the target package version and avoids compatibility fallbacks.",
+      "assertions": [
+        "The response checks __init__.py, defining source, tests, and package metadata",
+        "The response distinguishes source checkout from installed package",
+        "The response does not conceal the mismatch with try/except imports"
+      ]
+    }
+  ]
+}

--- a/skills/r2x-core/references/DATA_STORE.md
+++ b/skills/r2x-core/references/DATA_STORE.md
@@ -10,7 +10,7 @@ and `DataStore`.
 - `DataFile` must set exactly one path source: `fpath`, `relative_fpath`, or
   `glob`.
 - `FileInfo(description=None, is_input=True, is_optional=False, is_timeseries=False, units=None)`
-- `ReaderConfig(kwargs: dict[str, Any] = ..., function: Callable[[Path], Any] | None = None)`
+- `ReaderConfig(kwargs: dict[str, Any] = ..., function: Callable[..., Any] | None = None)`
 - `TabularProcessing(...)` declares many fields, but current tabular execution
   applies only lowercase, drop, rename, pivot, cast, filter, and select unless
   source has added more transformations.

--- a/skills/r2x-core/references/DISCOVERY.md
+++ b/skills/r2x-core/references/DISCOVERY.md
@@ -7,8 +7,8 @@ unfamiliar symbol, or docs and runtime behavior disagree.
 
 1. Installed/project source, source of truth for signatures and behavior.
 2. Local skill references in this directory for workflow intent.
-3. Project docs: <https://nrel.github.io/r2x-core/>
-4. Source repo: <https://github.com/NREL/r2x-core>
+3. Project docs: <https://natlabrockies.github.io/r2x-core/>
+4. Source repo: <https://github.com/NatLabRockies/r2x-core>
 5. infrasys docs/source for pure `System` / `Component` semantics.
 
 ## Key modules

--- a/skills/r2x-core/references/DISCOVERY.md
+++ b/skills/r2x-core/references/DISCOVERY.md
@@ -27,6 +27,9 @@ unfamiliar symbol, or docs and runtime behavior disagree.
 - `r2x_core.utils`: `UpgradeStep`, `UpgradeType`, `run_upgrade_step`
 - `r2x_core.result`: `RuleResult`, `TranslationResult`
 - `r2x_core.exceptions`: framework exceptions
+- `r2x_core.logger`: `setup_logging`, `get_logger`, sink and verbosity behavior
+- `R2X_CLI.md`: current `r2x` install, discovery, direct-run, pipeline, and
+  validation workflow
 
 ## Fast verification
 
@@ -53,6 +56,9 @@ package instead of this checkout.
 3. Use docs/examples only for intent and worked usage.
 4. If docs and source disagree, trust source and report the mismatch.
 5. In the handoff, name the decisive module or reference consulted.
+6. For logging work, inspect `src/r2x_core/logger.py` and
+   `tests/test_logger.py`; do not infer levels or sink behavior from generic
+   Loguru knowledge.
 
 ## Boundary rule
 

--- a/skills/r2x-core/references/LOGGING.md
+++ b/skills/r2x-core/references/LOGGING.md
@@ -1,0 +1,274 @@
+# r2x-core logging policy
+
+Use this reference when adding, reviewing, or debugging logs in r2x-core or a
+translator built on it. The policy follows the repository's Loguru setup in
+`src/r2x_core/logger.py`.
+
+## Logging contract
+
+- Use Loguru, not `print`, for library diagnostics.
+- r2x-core logging is disabled by default in `r2x_core.__init__` with
+  `logger.disable("r2x_core")`.
+- Every application or package built on r2x-core should disable its own
+  namespace at import time as well, for example
+  `logger.disable("my_translator")`. This keeps the package silent when it is
+  imported as a library.
+- The application or CLI entry point explicitly enables the namespaces it owns
+  before configuring sinks. `setup_logging(...)` enables the `r2x_core` namespace;
+  a custom Loguru setup must enable both namespaces itself.
+- Use `get_logger("component.name")` when a bound logger label is useful.
+  Its `name` value is structured metadata; it does not change Loguru's record
+  namespace used by `logger.disable(...)`.
+- Write structured context with `logger.bind(...)` or `logger.bind(...).info(...)`.
+- Use Loguru's `{}` formatting arguments, not f-strings in hot paths or when
+  the message does not need eager interpolation.
+- Keep stdout for a documented CLI/data contract. Logs go to stderr or a log
+  file.
+
+```python
+from r2x_core.logger import get_logger, setup_logging
+
+logger = get_logger("translator.parser")
+
+
+def read_inputs(path: str) -> None:
+    logger.debug("Reading input path={}", path)
+    logger.info("Input read started")
+
+
+if __name__ == "__main__":
+    setup_logging(verbosity=0)  # INFO and above on the console
+    read_inputs("inputs")
+```
+
+Library modules should not call `setup_logging()` during import. Importing a
+library must remain quiet until its owner explicitly enables a sink.
+
+## Application namespace opt-in
+
+Each application package should establish the same silent-by-default policy in
+its package initializer. Use the package namespace, not `__name__` from a CLI
+module, because Loguru's disable/enable controls match logger record names:
+
+```python
+# my_translator/__init__.py
+from loguru import logger
+
+logger.disable("my_translator")
+```
+
+The application entry point opts in after argument parsing and before it runs
+work. `setup_logging(...)` enables `r2x_core` and installs the repository's
+console/file sinks. Enable the application's own namespace separately:
+
+```python
+# my_translator/__main__.py
+from loguru import logger
+
+from r2x_core.logger import setup_logging
+
+
+def main() -> int:
+    # Parse flags first, then choose verbosity and sinks.
+    logger.enable("my_translator")
+    setup_logging(verbosity=1, log_file="run.log")  # DEBUG and above on console
+    logger.info("Application started")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+The `setup_logging` call also runs `logger.enable("r2x_core")`. An application
+using the helper therefore needs only `logger.enable("my_translator")` for its
+own records, provided those records originate in `my_translator.*` modules.
+If a CLI module is named `__main__`, use the package logger from an application
+module for package diagnostics, or enable the CLI module's actual record name
+as well. If the application owns a custom Loguru setup instead, enable both
+namespaces and add its own sink:
+
+```python
+from loguru import logger
+import sys
+
+logger.enable("my_translator")
+logger.enable("r2x_core")
+logger.remove()
+logger.add(sys.stderr, level="INFO", serialize=True)
+```
+
+Do not call `logger.disable("r2x_core")` after `setup_logging(...)`, and do not
+expect `logger.add(...)` alone to re-enable a disabled namespace. Enabling a
+namespace and adding a sink are separate operations. `setup_logging(...)`
+replaces existing Loguru sinks, so call it at the application boundary and do
+not call it from reusable library modules.
+
+## Loguru levels
+
+Loguru orders levels from least to most severe as follows:
+
+| Level | Use when | Examples | Do not use for |
+| --- | --- | --- | --- |
+| `TRACE` | Need highly detailed execution evidence to diagnose a specific path. | Per-rule field decisions, resolved paths, per-component attachment, processor steps, system-base assignment. | Normal progress, large payload dumps, secrets, or one log per row in a large dataset. |
+| `DEBUG` | Need developer diagnostics that explain decisions and state without being routine user output. | Starting a read, selected upgrade branch, registered getter, number of converted components, chosen file mapping. | Every loop iteration or a successful operation that users need to see by default. |
+| `INFO` | Report meaningful lifecycle milestones and normal outcomes. | Plugin started/completed, file mapping loaded, upgrade applied, system serialized, time-series transfer summary. | Detailed internals, warnings, or expected per-record activity. |
+| `SUCCESS` | Mark a prominent successful user operation only when the surrounding CLI/application already uses this level. | A completed top-level command with a clear user-facing outcome. | Ordinary library success. The current r2x-core formatter has no dedicated `SUCCESS` styling, so prefer `INFO` in framework/library code. |
+| `WARNING` | An abnormal or degraded condition is recoverable and execution continues. | Optional file skipped, no source components matched, duplicate rows removed, fallback path selected, persisted metadata ignored. | Expected branches, validation failures that abort, or a condition that makes the result unusable. |
+| `ERROR` | A specific operation failed or a recoverable boundary has an actionable failure. | One rule failed while aggregate execution records the failure, a configured upgrade step failed, an attachment cannot be made. | Logging the same exception repeatedly at every layer, or a fatal process decision that requires `CRITICAL`. |
+| `CRITICAL` | The application or workflow cannot continue safely and needs operator intervention. | Corrupt required runtime state, unavailable mandatory service, unrecoverable top-level startup failure. | Library code deciding to exit the process. Raise a typed exception and let the application boundary decide. |
+
+Use `logger.exception("...")` inside an `except` block when the traceback is
+needed. It emits an `ERROR` record with exception information. Do not use
+`logger.exception` for ordinary error strings outside an exception handler.
+
+## Choosing a level
+
+Ask these questions in order:
+
+1. **Would a caller normally need this to understand the result?** Use `INFO`.
+2. **Is it a recoverable abnormality that changes behavior?** Use `WARNING`.
+3. **Did a specific operation fail?** Use `ERROR`, preserving the operation and
+   relevant identifier.
+4. **Would continuing risk corrupting or misrepresenting the result?** Raise a
+   typed error. Use `CRITICAL` only at an application boundary that can act on
+   the failure.
+5. **Is this only useful for diagnosis?** Use `DEBUG` or `TRACE`, choosing
+   `TRACE` for high-volume or deeply internal detail.
+
+Log a state transition once at the boundary that owns it. Do not log the same
+failure in a helper, service, plugin, and CLI unless each layer adds materially
+different context.
+
+## Verbosity and sinks
+
+`setup_logging` configures console and optional file sinks:
+
+```python
+from r2x_core.logger import VERBOSITY_DEBUG, VERBOSITY_INFO, VERBOSITY_TRACE, setup_logging
+
+setup_logging(verbosity=VERBOSITY_INFO)   # INFO and above
+setup_logging(verbosity=VERBOSITY_DEBUG)  # console DEBUG and above
+setup_logging(verbosity=VERBOSITY_TRACE)  # console TRACE and above
+
+setup_logging(
+    verbosity=VERBOSITY_INFO,
+    log_file="run.log",
+    log_to_console=False,
+)
+```
+
+Current mappings are source-defined:
+
+- `verbosity=0` (`VERBOSITY_INFO`, the default) shows `INFO` and above on
+  the console.
+- `verbosity=1` (`VERBOSITY_DEBUG`) shows `DEBUG` and above.
+- `verbosity=2` (`VERBOSITY_TRACE`) shows `TRACE` and above and includes
+  timestamps in TTY output.
+- An unsupported verbosity value falls back to `WARNING` for console output.
+- A configured file sink always captures `TRACE` and above.
+- `log_to_console=False` suppresses the console sink but does not suppress a
+  configured file sink.
+- Calling `setup_logging` enables the `r2x_core` logger namespace and replaces
+  existing Loguru sinks. The caller owns this application-level configuration.
+
+Terminal output uses a compact Rich layout when stderr is a TTY. Non-TTY
+stderr receives JSON Lines suitable for CI and ingestion. File output uses the
+configured timestamped text format. Do not parse human TTY output; use the
+structured non-TTY stream or a file sink when automation needs logs.
+
+## Structured context
+
+Bind stable identifiers instead of interpolating a long diagnostic string:
+
+```python
+logger = get_logger("rules.executor").bind(
+    plugin="reeds_to_sienna",
+    rule="generator_to_unit",
+    run_id=run_id,
+)
+logger.info("Applying translation rule")
+logger.debug("Rule inputs resolved", source_type=source_type, target_type=target_type)
+```
+
+With the repository formatter, bound extras appear as terminal context and as
+additional JSON fields. Keep values scalar or compact and JSON-serializable:
+IDs, names, counts, paths, versions, and statuses are good. Avoid binding full
+systems, DataFrames, arrays, credentials, tokens, or arbitrary objects.
+
+Use stable message text and structured fields for values:
+
+```python
+logger.warning(
+    "Optional input skipped",
+    file_name=data_file.name,
+    path=str(path),
+    reason="file not found",
+)
+```
+
+The current codebase commonly uses positional Loguru formatting (`{}`) and
+bound `name` fields through `get_logger`. The bound `name` is metadata shown by
+structured sinks; namespace enable/disable still follows the originating
+module's record name. Follow the local style of the module being changed rather
+than mixing message styles in one area.
+
+## r2x-core examples by level
+
+```python
+logger.trace("Resolved relative_fpath={} for file={}", fpath, data_file.name)
+logger.debug("Applying rule: {}", rule)
+logger.info("Loading file mapping from {}", mapping_path)
+logger.warning("No components found for source type '{}' in rule {}", source_type, rule)
+logger.error("Rule {} failed: {}", rule, error)
+```
+
+These levels match the existing framework behavior:
+
+- Path resolution and per-component attachment are `TRACE`.
+- Reader starts, rule starts, and transformation details are `DEBUG`.
+- Store loading, serialization, and transfer summaries are `INFO`.
+- Optional skips, no-match conditions, and recoverable cleanup are `WARNING`.
+- Rule or attachment failures are `ERROR`.
+
+## Sensitive and high-volume data
+
+Never log secrets, credentials, access tokens, raw user data, or complete input
+payloads. Redact paths or identifiers when they contain sensitive information.
+For large inputs, log dimensions, names, counts, dtypes, versions, and checksums
+instead of contents. Guard expensive diagnostics with the appropriate level or
+move them to a bounded probe.
+
+```python
+logger.debug(
+    "Loaded profile",
+    rows=frame.height,
+    columns=frame.width,
+    column_names=frame.columns,
+)
+```
+
+Do not put `repr(system)`, a complete DataFrame, or an entire rule/configuration
+mapping into an INFO or WARNING message.
+
+## Error handling and tests
+
+- Log at the layer that can explain or handle the event.
+- Preserve the original exception with `raise ... from exc` or `Err(...)`.
+- If an exception is propagated unchanged, avoid logging it again at every
+  caller.
+- Use `logger.exception(...)` only when the traceback is useful to the current
+  boundary.
+- Test behavior through configured sinks when changing logging format, level
+  filtering, structured fields, or exception output. Restore Loguru sinks and
+  package enablement in fixtures.
+
+## Output expectations
+
+When changing logging, report:
+
+- The level selected for each new event and why.
+- Whether the event is library logging or an application/CLI boundary.
+- Bound structured fields and any redaction/truncation decisions.
+- Console/file sink and verbosity behavior validated.
+- Any remaining concern about volume, sensitive data, or duplicate records.

--- a/skills/r2x-core/references/PLUGINS.md
+++ b/skills/r2x-core/references/PLUGINS.md
@@ -34,13 +34,17 @@ function transforms.
   user-facing boundary requires it.
 - Do not add compatibility import fallbacks around `r2x_core` APIs unless the
   user explicitly asks for multi-version support.
+- Do not call `setup_logging()` from plugin/library import code. Configure sinks
+  at the application boundary and use the level policy in [LOGGING.md](./LOGGING.md).
+- Applications built on top of r2x-core should disable their package namespace
+  in `__init__.py` and enable it in the application entry point.
 
 ## Class plugin lifecycle
 
 A class plugin binds a translator to a typed `PluginConfig`.
 
 ```python
-from r2x_core import Ok, Plugin, PluginConfig, System
+from r2x_core import Ok, Plugin, PluginConfig, Result, System
 
 
 class MyConfig(PluginConfig):
@@ -49,11 +53,11 @@ class MyConfig(PluginConfig):
 
 
 class MyTranslator(Plugin[MyConfig]):
-    def on_prepare(self):
+    def on_prepare(self) -> Result[None, str]:
         self.ctx.metadata["prepared"] = True
         return Ok(None)
 
-    def on_build(self):
+    def on_build(self) -> Result[System, str]:
         return Ok(System(name=f"model_{self.config.model_year}"))
 ```
 
@@ -115,6 +119,7 @@ best for focused system transformations without a class lifecycle.
 
 ```python
 from rust_ok import Err, Ok, Result
+
 from r2x_core import PluginConfig, System, expose_plugin
 
 
@@ -138,6 +143,29 @@ Function transform guidance:
 - Surface validation or domain failures as `Err(...)`, not exceptions.
 - Direct Python calls should work; entry-point discovery is an integration
   layer, not the only execution path.
+
+## Logging in plugins
+
+Use the logger level that matches the event, and keep plugin context in bound
+fields rather than embedding large values in messages:
+
+```python
+from r2x_core.logger import get_logger
+
+logger = get_logger("plugins.reeds").bind(plugin="ReEDS")
+# Keep this module under the `my_translator.*` package namespace so the
+# application-level logger.enable("my_translator") opt-in covers its records.
+logger.info("Plugin preparation started: input_folder={}", self.config.input_folder)
+logger.debug("Resolved input files: file_count={}", len(self.store.list_data()))
+logger.warning("Optional input skipped: file_name={}", "overrides")
+```
+
+Use `TRACE` for per-component or path-resolution detail, `DEBUG` for decisions,
+`INFO` for lifecycle milestones, `WARNING` for recoverable degradation, and
+`ERROR` for an operation failure. Let `Plugin.run()` own the final
+`PluginError` boundary instead of logging and re-raising the same hook failure
+at every layer. See [LOGGING.md](./LOGGING.md) for sink, verbosity, and
+sensitive-data rules.
 
 ## Entry points
 

--- a/skills/r2x-core/references/QUICKREF.md
+++ b/skills/r2x-core/references/QUICKREF.md
@@ -1,6 +1,8 @@
-# r2x-core QUICKREF
+# r2x-core public API quick reference
 
-One-page fast reference for the most-used r2x-core APIs.
+Start here for every r2x-core implementation or review. These call shapes are
+verified against this checkout's `src/r2x_core/__init__.py`, source modules, and
+tests. If the installed package is the target, inspect its source separately.
 
 ## Core calls
 
@@ -8,7 +10,7 @@ One-page fast reference for the most-used r2x-core APIs.
 # plugin
 ctx = PluginContext(config=my_config)
 plugin = MyPlugin.from_context(ctx)
-ctx = plugin.run()  # raises PluginError on first hook Err
+ctx = plugin.run()  # returns PluginContext, raises PluginError on hook Err
 
 # rules
 ctx = ctx.evolve(
@@ -24,6 +26,15 @@ store = DataStore(path="/data")
 store.add_data([DataFile(name="loads", relative_fpath="load.csv")])
 loads = store.read_data("loads")
 
+# logging, disabled in the package and enabled at the application boundary
+from loguru import logger
+from r2x_core.logger import get_logger, setup_logging
+logger.disable("my_translator")  # in my_translator/__init__.py
+logger.enable("my_translator")  # in the app entry point
+setup_logging(verbosity=1)  # DEBUG+ console, also enables r2x_core
+logger = get_logger("translator.parser")  # metadata label, not namespace
+logger.info("Translation started")
+
 # upgrades
 result = run_upgrade_step(payload, step=step)
 
@@ -34,35 +45,83 @@ mode = get_unit_system()
 
 ## Contract checklist
 
-- `Plugin.run(*, ctx=None) -> PluginContext` (not `Result`)
-- `apply_rules_to_context(context)` only, rules come from `context.rules`
-- rule execution reads `context.source_system` and writes `context.target_system`
+- `Plugin.run(*, ctx=None) -> PluginContext`, not `Result`
+- `apply_rules_to_context(context)`, rules come from `context.rules`
+- Rule execution reads `context.source_system` and writes `context.target_system`
 - `apply_single_rule(rule, *, context=...)`
 - `DataFile` path source is exactly one of `fpath`, `relative_fpath`, `glob`
+- `DataFile` options are `info`, `reader`, and `proc_spec`
 - `DataStore.add_data(...)` expects a sequence of `DataFile`
-- `VersionReader` is a protocol, implement `read_version(...)`
+- `VersionReader` is a protocol with `read_version(...)`
 - `UpgradeStep` uses `target_version`, optional `min_version` / `max_version`
 - `run_upgrade_step(data, *, step=...)`
+- Loguru is disabled by default for r2x-core and each consuming application
+- Disable your application namespace in its package initializer, then enable it
+  and call `setup_logging(...)` from the application entry point
+- `TRACE` internals, `DEBUG` decisions, `INFO` milestones, `WARNING` degradation,
+  `ERROR` failed operations, `CRITICAL` outer unrecoverable failures
 
-## Wrong vs correct
+## Wrong versus correct
 
-| Wrong                                                        | Correct                                                                         |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| `RuleFilter(lambda x: ...)`                                  | `RuleFilter(field="status", op="eq", values=["active"])`                        |
-| `apply_rules_to_context(context, rules)`                     | `context = context.evolve(rules=tuple(rules)); apply_rules_to_context(context)` |
-| `apply_single_rule(context, rule)`                           | `apply_single_rule(rule, context=context)`                                      |
-| `is_err(plugin.run())`                                       | `try: ctx = plugin.run(); except PluginError: ...`                              |
-| `DataFile(reader_config=..., processing=..., file_info=...)` | `DataFile(reader=..., proc_spec=..., info=...)`                                 |
-| `VersionReader(strategy=...)`                                | `class MyReader(VersionReader): ...`                                            |
-| `UpgradeStep(from_version=..., to_version=...)`              | `UpgradeStep(target_version=..., min_version=..., max_version=...)`             |
-| `run_upgrade_step(step, payload)`                            | `run_upgrade_step(payload, step=step)`                                          |
+| Wrong                                                        | Correct                                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `RuleFilter(lambda x: ...)`                                  | `RuleFilter(field="status", op="eq", values=["active"])`            |
+| `apply_rules_to_context(context, rules)`                     | `ctx = ctx.evolve(rules=tuple(rules)); apply_rules_to_context(ctx)` |
+| `apply_single_rule(context, rule)`                           | `apply_single_rule(rule, context=context)`                          |
+| `is_err(plugin.run())`                                       | `try: ctx = plugin.run(); except PluginError: ...`                  |
+| `DataFile(reader_config=..., processing=..., file_info=...)` | `DataFile(reader=..., proc_spec=..., info=...)`                     |
+| `VersionReader(strategy=...)`                                | Implement `read_version(folder_path)`                               |
+| `UpgradeStep(from_version=..., to_version=...)`              | `UpgradeStep(target_version=..., min_version=..., max_version=...)` |
+| `run_upgrade_step(step, payload)`                            | `run_upgrade_step(payload, step=step)`                              |
 
-## Pick the right doc
+## Minimal class plugin
 
-- Plugin lifecycle and registration: `PLUGINS.md`
-- Rules and filters: `RULES.md`
-- Data loading and readers: `DATA_STORE.md`
-- Units and display modes: `UNITS.md`
-- Versioning and upgrades: `VERSIONING_UPGRADES.md`
-- Shared utilities: `UTILITIES.md`
-- Full cross-cutting guide: `REFERENCE.md`
+```python
+from r2x_core import Plugin, PluginConfig, PluginContext, System
+from rust_ok import Ok, Result
+
+
+class Config(PluginConfig):
+    name: str = "demo"
+
+
+class Build(Plugin[Config]):
+    def on_build(self) -> Result[System, str]:
+        return Ok(System(name=self.config.name))
+
+
+context = Build.from_context(PluginContext(config=Config())).run()
+assert context.system is not None
+```
+
+## Minimal rule context
+
+```python
+from r2x_core import PluginConfig, PluginContext, Rule, System, apply_rules_to_context
+
+rule = Rule(
+    name="bus_to_node",
+    source_type="BusComponent",
+    target_type="NodeComponent",
+    version=1,
+    field_map={"name": "name", "kv_rating": "voltage_kv"},
+)
+context = PluginContext(
+    config=PluginConfig(models=("source_models", "target_models")),
+    source_system=source_system,
+    target_system=System(name="target"),
+    rules=(rule,),
+)
+translation = apply_rules_to_context(context)
+```
+
+## Focused references
+
+- Plugins: `PLUGINS.md`
+- Rules: `RULES.md`
+- Data: `DATA_STORE.md`
+- Units: `UNITS.md`
+- Upgrades: `VERSIONING_UPGRADES.md`
+- Utilities: `UTILITIES.md`
+- Discovery: `DISCOVERY.md`
+- Cross-cutting contracts: `REFERENCE.md`

--- a/skills/r2x-core/references/R2X_CLI.md
+++ b/skills/r2x-core/references/R2X_CLI.md
@@ -102,12 +102,19 @@ create an entry point.
 
 ## Validate discovery before running
 
-Use the repository-local API probe and plugin probe first:
+Use the repository-local API probe first, then run the plugin probe from the
+Python environment that contains the translator package:
 
 ```bash
 uv run python skills/r2x-core/tools/check_api_symbols.py --repo src/r2x_core
 uv run python skills/r2x-core/tools/inspect_plugins.py --group r2x_plugin
 ```
+
+The plugin probe reads installed entry points from the active Python environment.
+The r2x-core checkout itself does not define an `r2x_plugin` entry point, so
+`No entry points found for group 'r2x_plugin'.` is expected when the probe is
+run here without an installed translator. Run it from the translator checkout or
+its r2x-managed environment to inspect actual plugins.
 
 Then use the CLI to refresh its manifest and inspect installed plugins:
 

--- a/skills/r2x-core/references/R2X_CLI.md
+++ b/skills/r2x-core/references/R2X_CLI.md
@@ -1,0 +1,309 @@
+# r2x CLI integration
+
+Use this reference when developing an r2x-core plugin that will be installed,
+discovered, validated, or executed by the Rust `r2x` CLI. The CLI repository is
+[`NatLabRockies/r2x-cli`](https://github.com/NatLabRockies/r2x-cli). The binary is
+called `r2x`, not `r2x-cli`.
+
+## What the CLI does
+
+`r2x` discovers installed Python plugins, builds a plugin manifest, manages the
+Python environment, and executes plugins as direct commands or YAML pipeline
+steps. It uses static analysis for discovery, so an entry point and decorated
+function must be visible in the installed package metadata/source layout.
+
+Keep the responsibilities separate:
+
+- r2x-core defines the Python plugin API and runtime behavior.
+- The plugin package defines `PluginConfig`, `Plugin`, components, rules, and
+  entry points.
+- `r2x` installs packages, discovers plugin metadata, resolves CLI arguments,
+  and runs pipeline steps.
+
+## Install and verify the published CLI
+
+Install the latest released binary on macOS/Linux:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/NatLabRockies/r2x-cli/releases/latest/download/r2x-installer.sh | sh
+```
+
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/NatLabRockies/r2x-cli/releases/latest/download/r2x-installer.ps1 | iex"
+```
+
+Verify the command before installing plugins:
+
+```bash
+r2x --version
+r2x --help
+```
+
+The published binary requires Python shared libraries at runtime. If the
+binary reports a missing `libpython`, install a supported shared Python with
+`uv`:
+
+```bash
+uv python install 3.12
+```
+
+Use the published installers or release binaries only. Do not build `r2x` from
+source as part of the r2x-core plugin workflow. If the published binary is
+unavailable for the platform, stop and report that limitation rather than
+silently switching to a source build.
+
+## Install a plugin package
+
+Use the CLI to install the Python package into the r2x-managed environment:
+
+```bash
+r2x install r2x-reeds
+r2x list
+r2x sync
+```
+
+For a GitHub source or editable local package:
+
+```bash
+r2x install gh:NatLabRockies/r2x-reeds
+r2x install -e /path/to/my-translator
+r2x sync
+```
+
+Use `r2x install ... --branch`, `--tag`, or `--commit` when a non-default
+revision is required. Run `r2x sync --upgrade` only when upgrading compatible
+installed plugin packages is intended.
+
+## Plugin package contract
+
+A class-based r2x-core plugin package should expose its package/plugin metadata
+through the `r2x_plugin` entry-point group:
+
+```toml
+[project.entry-points.r2x_plugin]
+reeds = "r2x_reeds.plugins:ReEDSPlugin"
+```
+
+A function transform marked with `@expose_plugin` is discovered in the
+`r2x.transforms` group:
+
+```toml
+[project.entry-points."r2x.transforms"]
+scale_system = "r2x_reeds.transforms:scale_system"
+```
+
+Confirm the current consuming CLI behavior before changing metadata. The CLI
+supports both groups, but the class package entry point and transform entry
+point have different roles. A decorator alone does not install a package or
+create an entry point.
+
+## Validate discovery before running
+
+Use the repository-local API probe and plugin probe first:
+
+```bash
+uv run python skills/r2x-core/tools/check_api_symbols.py --repo src/r2x_core
+uv run python skills/r2x-core/tools/inspect_plugins.py --group r2x_plugin
+```
+
+Then use the CLI to refresh its manifest and inspect installed plugins:
+
+```bash
+r2x sync
+r2x list
+r2x list r2x-reeds
+r2x run plugin
+```
+
+For a specific plugin, ask the CLI to render the resolved argument contract:
+
+```bash
+r2x run plugin r2x-reeds.reeds-parser --show-help
+```
+
+If the CLI cannot see a plugin that Python can import, compare these layers:
+
+1. The package is installed in the r2x-managed environment, not only the
+   repository's development `.venv`.
+2. The package metadata contains `[r2x_plugin]` or `[r2x.transforms]`.
+3. The entry-point target has the correct import path.
+4. `@expose_plugin` is applied directly to a function for transform discovery.
+5. `r2x sync` has refreshed stale manifest metadata.
+6. The plugin source is in the installed distribution files scanned by the CLI.
+
+## Run a plugin directly
+
+Use the short direct-plugin form:
+
+```bash
+r2x run r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012
+```
+
+The legacy explicit form remains useful when disambiguating command modes:
+
+```bash
+r2x run plugin r2x-reeds.reeds-parser --show-help
+```
+
+Use idiomatic flags for automation. Existing `key=value` arguments are also
+accepted by current CLI behavior, but do not mix both forms for the same field:
+
+```bash
+r2x run r2x-reeds.reeds-parser \
+  path=/path/to/reeds/run \
+  solve_year=2030 \
+  weather_year=2012
+```
+
+A plugin that produces a `System` writes JSON to stdout when no output path is
+provided. Diagnostics belong on stderr. Use `-o` for a durable JSON entrypoint
+and its time-series sidecars:
+
+```bash
+r2x run r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012 \
+  -o artifacts/system.json
+
+r2x run r2x-reeds.add-pcm-defaults \
+  -i artifacts/system.json \
+  --pcm-defaults-fpath config/pcm_defaults.json
+```
+
+Do not parse diagnostic text from stdout when a plugin is expected to produce a
+System. Use stderr for logs and stdout for the pipeline artifact.
+
+## Compose plugins as a Unix stream
+
+Use `set -o pipefail` and keep the producer/consumer boundary clean:
+
+```bash
+set -o pipefail
+r2x run r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012 |
+r2x run r2x-reeds.add-pcm-defaults \
+  --pcm-defaults-fpath config/pcm_defaults.json
+```
+
+Use durable `-o` / `-i` boundaries when debugging, rerunning, or retaining
+artifacts. A terminal exporter writes configured files and should not emit a
+second JSON artifact into the stream.
+
+## Run and validate a YAML pipeline
+
+Create or inspect a pipeline file with `r2x init`, then list and preview before
+execution:
+
+```bash
+r2x init
+r2x run pipeline.yaml --list
+r2x run pipeline.yaml --print reeds-to-plexos
+r2x run pipeline.yaml reeds-to-plexos --dry-run
+```
+
+A pipeline must use the same plugin identifier under `pipelines` and `config`:
+
+```yaml
+variables:
+  reeds_run: /data/reeds/run
+  solve_year: 2030
+
+pipelines:
+  reeds-to-sienna:
+    - r2x-reeds.reeds-parser
+    - r2x-sienna.sienna-exporter
+
+config:
+  r2x-reeds.reeds-parser:
+    path: ${reeds_run}
+    solve_year: ${solve_year}
+    weather_year: 2012
+  r2x-sienna.sienna-exporter:
+    output_path: output/system.json
+
+output_folder: output
+```
+
+After the dry run succeeds, execute and retain the output:
+
+```bash
+r2x run pipeline.yaml reeds-to-sienna --output output/system.json
+```
+
+Use `--list` to validate the pipeline name and `--print` to inspect resolved
+configuration without executing plugins. Use `--dry-run` to verify ordering and
+configuration without touching translation inputs.
+
+## CLI verbosity and logs
+
+The CLI owns its Rust and process-level logging. Use:
+
+```bash
+r2x run pipeline.yaml reeds-to-sienna -q
+r2x run pipeline.yaml reeds-to-sienna -v
+r2x run pipeline.yaml reeds-to-sienna -vv
+r2x log show
+r2x log set log-python true
+r2x log set no-stdout true
+r2x log path
+```
+
+- `-q` suppresses informational status.
+- `-qq` suppresses logs and plugin stdout capture.
+- `-v` enables debug logging.
+- `-vv` enables trace logging.
+- `--log-python` shows Python/plugin logs on the console.
+- `--no-stdout` keeps plugin stdout out of the log file.
+
+This is separate from the Python Loguru policy in [LOGGING.md](./LOGGING.md).
+The CLI controls what it captures and displays, while the application/plugin
+controls its Loguru namespace and `r2x_core.logger.setup_logging(...)` sinks.
+
+## Validation checklist
+
+Before handing off an r2x-core plugin intended for `r2x`:
+
+1. Run focused Python tests for the public plugin, config, reader, and rule
+   behavior.
+2. Run `uv run python skills/r2x-core/tools/check_api_symbols.py --repo src/r2x_core`.
+3. Install the plugin into the r2x-managed environment with `r2x install -e .`.
+4. Run `r2x sync` and confirm the package appears in `r2x list`.
+5. Run `r2x run plugin <plugin-ref> --show-help`.
+6. Preview every pipeline with `--list`, `--print`, and `--dry-run`.
+7. Run one bounded real translation with `-o` and verify the output JSON and
+   time-series sidecars.
+8. Run a second step from the durable output with `-i` or a bounded pipe.
+9. Check exit status and stderr separately from stdout. Use `pipefail` for
+   pipelines.
+10. If installation or discovery changed, repeat `r2x sync` after reinstalling
+    rather than trusting stale manifest metadata.
+
+## Failure triage
+
+- **`r2x list` does not show the package:** reinstall it into the managed
+  environment, run `r2x sync`, and inspect package metadata for the entry-point
+  group.
+- **Plugin help has missing or wrong flags:** inspect `PluginConfig` fields and
+  annotations, then reinstall and sync so the manifest is regenerated.
+- **Direct plugin works in Python but not through `r2x`:** verify the package
+  distribution contains the module and that the entry-point target is valid.
+- **Pipeline name not found:** run `r2x run pipeline.yaml --list`; check the
+  YAML `pipelines` key and exact identifier spelling.
+- **Dry run passes but execution fails:** validate real input paths, reader
+  configuration, plugin dependencies, and the subprocess stderr. Dry run does
+  not read or translate model data.
+- **Piped output is corrupt:** keep diagnostics on stderr, avoid printing in
+  plugin code, and use durable `-o` / `-i` boundaries to isolate the failing
+  stage.
+- **Python logs are missing:** enable the consuming application namespace,
+  configure Loguru at the application boundary, then use `--log-python` or
+  `r2x log set log-python true`.

--- a/skills/r2x-core/references/REFERENCE.md
+++ b/skills/r2x-core/references/REFERENCE.md
@@ -1,280 +1,178 @@
-# r2x-core Reference
+# r2x-core cross-cutting reference
 
-## Contracts (authoritative signatures)
-
-- `Plugin.run(*, ctx: PluginContext | None = None) -> PluginContext`
-- `apply_rules_to_context(context: PluginContext) -> TranslationResult`
-- `apply_single_rule(rule: Rule, *, context: PluginContext) -> Result[RuleApplicationStats, ValueError]`
-- `DataStore.add_data(data_files: Sequence[DataFile], *, overwrite: bool = False) -> None`
-- `DataStore.read_data(name: str, *, placeholders: dict[str, Any] | None = None) -> Any`
-- `VersionReader.read_version(folder_path: Path) -> str | None` (protocol)
-- `run_upgrade_step(data, *, step: UpgradeStep, upgrader_context=None) -> Result[Any, str]`
-
-## Wrong patterns (do not use)
-
-- `RuleFilter(lambda ...)`
-- `apply_rules_to_context(context, rules)`
-- `apply_single_rule(context, rule)`
-- Treating `plugin.run()` as `Result` (`is_err(result)`, `result.ok()`)
-- `DataFile(reader_config=..., processing=..., file_info=...)`
-- `VersionReader(strategy=...)`
-- `UpgradeStep(from_version=..., to_version=...)`
-- `run_upgrade_step(step, payload)`
-
-## When to use
-
-Use this skill for concrete r2x-core operations that touch its public
-surface: declaring plugins, wiring `PluginContext`, defining rules and
-filters, configuring a `DataStore`, applying per-unit semantics, or running
-upgrade steps. r2x-core is a translation framework built on top of infrasys;
-keep infrasys-internal modeling questions in the `infrasys` skill.
-
-## Avoid when
-
-- Task is purely an infrasys `System` / `Component` modeling question.
-- Task is generic Python or unrelated tooling.
-
-## Additional reference documents
-
-- [QUICKREF.md](./QUICKREF.md), one-page call signatures and gotchas.
-- [PLUGINS.md](./PLUGINS.md), plugin lifecycle, hook capabilities, exposure,
-  registration, and `PluginContext`.
-- [RULES.md](./RULES.md), `Rule`, `RuleFilter`, and rule executor semantics.
-- [DATA_STORE.md](./DATA_STORE.md), `DataStore`, `DataFile`, `ReaderConfig`,
-  HDF5 readers.
-- [UNITS.md](./UNITS.md), per-unit system and display modes.
-- [VERSIONING_UPGRADES.md](./VERSIONING_UPGRADES.md), upgrade steps and
-  version strategies.
-- [UTILITIES.md](./UTILITIES.md), common extraction, creation, export, getter,
-  and time-series helpers.
-- [DISCOVERY.md](./DISCOVERY.md), how to find authoritative sources.
-- [../evals/TRIGGER_PROMPTS.md](../evals/TRIGGER_PROMPTS.md), should-trigger
-  and near-miss prompts.
+Use this reference when a task spans multiple r2x-core surfaces or when a
+public contract, result boundary, or persistence decision is unclear. Start
+with [QUICKREF.md](./QUICKREF.md) for exact calls, then load the focused file.
 
 ## Mental model
 
-- r2x-core is the **translator framework**: it owns plugin lifecycle, rule
-  execution, file ingestion, units, and versioning. It does **not** own the
-  domain `System` / `Component` schema, that is infrasys.
-- Translation flows in stages: **prepare** (load inputs) -> **build** (create
-  the `System`) -> **transform / translate** (apply `Rule`s) -> **export**
-  (emit artifacts) -> **cleanup**.
-- All lifecycle hooks return `Result[T, E]` from `rust_ok`. Never raise for
-  control flow.
-- Configuration is **typed**, always a `PluginConfig` subclass (Pydantic v2)
-  rather than loose `dict[str, Any]`.
+r2x-core is the translator framework around infrasys:
 
-## Public API surface (high-signal entry points)
+```text
+DataFile definitions -> DataStore/DataReader -> PluginContext
+                                      -> Plugin hooks
+                                      -> Rule executor
+                                      -> target System -> export/persistence
+```
+
+It owns plugin lifecycle, rule execution, file ingestion, units, and upgrades.
+It does not own domain `System` / `Component` definitions.
+
+For execution through the Rust `r2x` CLI, read [R2X_CLI.md](./R2X_CLI.md).
+
+## Public root surface
+
+Use root imports when exported by `src/r2x_core/__init__.py`:
 
 ```python
 from r2x_core import (
-    # Plugin system
-    Plugin, PluginConfig, PluginContext, PluginError, expose_plugin,
-    # Rules
-    Rule, RuleFilter, RuleResult, TranslationResult,
-    apply_rules_to_context, apply_single_rule,
-    # Data
-    DataStore, DataFile, DataReader, FileInfo,
-    ReaderConfig, TabularProcessing, JSONProcessing,
-    FileFormat, H5Format,
-    # System (r2x-core wrapper around infrasys.System)
-    System,
-    # Units
-    HasUnits, HasPerUnit, Unit, UnitSystem,
-    get_unit_system, set_unit_system,
-    # Versioning and upgrades
-    VersionStrategy, SemanticVersioningStrategy, GitVersioningStrategy,
-    VersionReader,
-    UpgradeStep, UpgradeType, run_upgrade_step,
-    # Result helpers
-    Ok, Err, Result, is_ok, is_err,
-    # Utilities
-    create_component, components_to_records, export_components_to_csv,
-    getter, h5_readers,
-    # Errors
-    CLIError, ComponentCreationError, ValidationError, UpgradeError,
+    CLIError, ComponentCreationError, DataFile, DataReader, DataStore, Err,
+    FileInfo, FileFormat, GitVersioningStrategy, H5Format, HasPerUnit,
+    HasUnits, JSONProcessing, Ok, Plugin, PluginConfig, PluginContext,
+    PluginError, ReaderConfig, Result, Rule, RuleFilter, RuleResult,
+    SemanticVersioningStrategy, System, TabularProcessing, TranslationResult,
+    Unit, UnitSystem, UpgradeError, UpgradeStep, UpgradeType, ValidationError,
+    VersionReader, VersionStrategy, apply_rules_to_context, apply_single_rule,
+    components_to_records, create_component, export_components_to_csv,
+    expose_plugin, get_unit_system, getter, h5_readers, is_err, is_ok,
+    run_upgrade_step, set_unit_system,
 )
 ```
 
-The full `__all__` lives in `src/r2x_core/__init__.py`. If a symbol you need
-is not re-exported there, treat it as private and avoid importing from a
-submodule unless you are extending the framework itself.
+If the symbol is not in `__all__`, treat it as private unless you are extending
+r2x-core itself. Do not create local fallback imports to hide API drift.
 
-## Core call patterns
+## Contract matrix
 
-### 1. Define a typed config and a plugin
+| Surface | Public boundary | Success/failure |
+| --- | --- | --- |
+| Plugin lifecycle | `Plugin.from_context(ctx).run()` | `PluginContext`; hook `Err` raises `PluginError` |
+| Function transform | `@expose_plugin` + explicit call | usually `Result[System, E]` |
+| All rules | `apply_rules_to_context(context)` | `TranslationResult` with `RuleResult` records |
+| One rule | `apply_single_rule(rule, *, context=...)` | `Result[RuleApplicationStats, ValueError]` |
+| File read | `DataReader.read_data_file(...)` | format-specific payload or exception |
+| Store read | `DataStore.read_data(name, ...)` | format-specific payload or exception |
+| Unit setting | `set_unit_system(...)` | process-global display state |
+| Logging | Loguru + `setup_logging(...)` | disabled by default; application-owned sinks |
+| One upgrade | `run_upgrade_step(data, *, step=...)` | `Result[Any, str]` |
+| Component creation | `create_component(component_class, *, skip_none=True, skip_validation=False, **field_values)` | `Result[Component, pydantic.ValidationError]` |
 
-```python
-from r2x_core import Plugin, PluginConfig, Ok, Err
+## Result and exception boundaries
 
-class ReEDSConfig(PluginConfig):
-    input_folder: str
-    model_year: int
-    scenario: str = "base"
+Use the project's established boundary, not a universal rule:
 
-class ReEDSTranslator(Plugin[ReEDSConfig]):
-    def on_prepare(self):
-        # load inputs into self.ctx as needed
-        return Ok(None)
+- Hook and upgrade functions return `Ok`/`Err` when the framework contract says
+  `Result`.
+- `Plugin.run()` deliberately raises `PluginError` after a hook returns `Err`.
+  Catch that only at an outer orchestration boundary.
+- `apply_rules_to_context` returns a rich result and records individual rule
+  failures; inspect `translation.rule_results`.
+- `DataFile`/`DataStore` validation and file reads use Pydantic and ordinary
+  exceptions such as `ValidationError`, `FileNotFoundError`, `KeyError`, or
+  `ReaderError` according to the source path.
+- `create_component` returns `Err(PydanticValidationError)` rather than raising
+  a validation error for normal invalid input.
 
-    def on_build(self):
-        from r2x_core import System
-        system = System(name=f"{self.config.scenario}_{self.config.model_year}")
-        return Ok(system)
-```
+Do not bare-unwrap result values in production code. Do not catch broad
+`Exception` to continue a translation, hide an API mismatch, or return `None`.
+Catch narrow exceptions at the boundary that can add useful context.
 
-### 2. Wire context and run
+## Logging policy
 
-```python
-from r2x_core import PluginContext
+Use [LOGGING.md](./LOGGING.md) for the complete level and sink policy. The
+short version is:
 
-config = ReEDSConfig(input_folder="/data/reeds", model_year=2030)
-context = PluginContext(config=config)
-plugin = ReEDSTranslator.from_context(context)
-result = plugin.run()
-```
+- Use Loguru, not `print`, for library diagnostics.
+- `r2x_core` logging is disabled by default. Every application built on top of
+  it should also call `logger.disable("my_application")` in its package
+  initializer, then call `logger.enable("my_application")` at its application
+  entry point. Enable r2x-core and configure sinks with `setup_logging(...)` at
+  the application boundary, never during import.
+- Use `TRACE` for high-volume internals, `DEBUG` for developer diagnostics,
+  `INFO` for meaningful lifecycle milestones, `WARNING` for recoverable degraded
+  behavior, `ERROR` for a failed operation, and `CRITICAL` only at an outer
+  boundary that can act on an unrecoverable condition.
+- Keep logs structured with `get_logger(...).bind(...)` or bound extras. Do not
+  log secrets, complete payloads, or high-volume records.
+- TTY output is human-oriented; non-TTY stderr is JSON Lines and file sinks
+  capture `TRACE` and above. Do not parse TTY text in automation.
 
-`plugin.run()` returns `PluginContext` and raises `PluginError` on the first
-failing hook.
+## Typed Python patterns
 
-### 3. Expose function transforms for entry-point discovery
-
-`@expose_plugin` marks plain function transforms, not class plugins.
-
-```python
-from rust_ok import Ok, Result
-from r2x_core import PluginConfig, System, expose_plugin
-
-class TransformConfig(PluginConfig):
-    scale: float = 1.0
-
-@expose_plugin
-def scale_system(system: System, config: TransformConfig) -> Result[System, str]:
-    return Ok(system)
-```
-
-Typical function-transform entry point:
-
-```toml
-[project.entry-points."r2x.transforms"]
-scale_system = "my_pkg.transforms:scale_system"
-```
-
-Class plugin entry-point group names have drifted in docs. Verify current
-source/discovery before editing `pyproject.toml`.
-
-### 4. Configure a `DataStore`
+Follow the repository's Python standards around r2x-core APIs:
 
 ```python
-from r2x_core import DataStore, DataFile
+from pathlib import Path
+from typing import Annotated
+from pydantic import Field
 
-store = DataStore(path="/data/reeds")
-store.add_data([
-    DataFile(name="generators", relative_fpath="gen.csv"),
-    DataFile(name="loads", relative_fpath="load.parquet"),
-])
-df = store.read_data("generators")
+
+def resolve_input(
+    path: Path,
+    *,
+    base_folder: Path,
+    must_exist: bool = True,
+) -> Path:
+    ...
+
+
+class InputConfig(PluginConfig):
+    folder: Annotated[Path, Field(description="Input folder")]
+    year: Annotated[int, Field(ge=2020, description="Planning year")]
 ```
 
-For HDF5 files, extension detection yields `H5Format`; configure layout with
-`ReaderConfig(kwargs=...)`; see [DATA_STORE.md](./DATA_STORE.md).
+Prefer canonical r2x-core, infrasys, or component models over duplicate local
+schemas. Use `Annotated`, constrained fields, Pydantic v2 validators, named
+structured returns, and protocols. Keep CLI parsing at the process boundary.
 
-### 5. Declare and run rules
+## Public API workflow
 
-```python
-from r2x_core import Rule, apply_rules_to_context
+1. Identify the canonical owner of the model/data/system concept.
+2. Read root exports and the defining module.
+3. Read nearby tests for exact arguments, result access, and failure behavior.
+4. Use the focused skill reference for workflow and known traps.
+5. Implement the smallest public behavior change.
+6. Add a test through the public interface and run it.
+7. Round-trip persistence or real file readers when the boundary changed.
 
-rules = [
-    Rule(
-        name="translate_generators",
-        source_type="SourceGenerator",
-        target_type="Generator",
-        version=1,
-        field_map={"name": "name", "capacity": "p_max_mw"},
-    ),
-]
-context = context.evolve(
-    source_system=source_system,
-    target_system=target_system,
-    rules=tuple(rules),
-)
-result = apply_rules_to_context(context)
-```
+## Persistence
 
-For a single rule pass, use `apply_single_rule(rule, context=context)`.
-
-## API contracts (high-signal behavior)
-
-- `Plugin.run()` orchestrates implemented hooks in order; missing hooks are
-  skipped. The first hook `Err` is surfaced as a raised `PluginError`.
-- `Plugin.get_implemented_hooks()` returns the set of hook names actually
-  overridden on the subclass; use it for capability reporting.
-- `Plugin.get_config_type()` returns the resolved `PluginConfig` subclass.
-- `PluginContext` carries config, store, systems, rules, and metadata. It uses
-  `__slots__`; do not attach arbitrary attributes.
-- `apply_rules_to_context(context)` returns a `TranslationResult`
-  aggregating per-rule `RuleResult` records.
-- `RuleFilter` composes with nested `any_of` / `all_of` declarative clauses.
-- `DataStore.read_data(name)` returns the materialized payload using the
-  reader chosen for the registered `DataFile`.
-- `DataStore.list_data()` returns the names of registered files; use this
-  for inventory.
-- HDF5 access goes through r2x-core readers; use `ReaderConfig(kwargs=...)` to
-  declare layout intent rather than reading raw datasets in plugin code.
-- `set_unit_system(UnitSystem.X)` is process-wide. Plugins should set it at
-  the boundary they own and not toggle it mid-translation.
-- `run_upgrade_step(payload, step=step)` applies a single `UpgradeStep` and
-  returns a `Result`; chain steps deterministically with explicit ordering.
-
-## Failure playbook
-
-- `PluginError` raised on registration:
-  - Confirm entry-point group/name and import target in `pyproject.toml`.
-  - Inspect `importlib.metadata.entry_points(group="r2x_plugin")` in the
-    active environment to confirm visibility.
-- `ValidationError` from `PluginConfig`:
-  - Inspect the Pydantic error tree; do not catch and reformat. Fix the
-    config schema or input.
-- Hook returns `Err` and translation halts:
-  - `Plugin.run()` raises `PluginError`; catch it at the boundary where you
-    want to map framework errors.
-- Rule silently skips components:
-  - Inspect `RuleFilter` composition (precedence) and rule `version`.
-  - Confirm `source_type` actually exists in the source records.
-- DataStore raises on `read_data`:
-  - Verify `DataFile` paths resolve under `store.folder`.
-  - Confirm the file extension maps to a known `FileFormat`; otherwise
-    declare `ReaderConfig` explicitly.
-  - Use `store.list_data()` and inspect each `DataFile` mapping before
-    debugging reader internals.
-- Unit conversions disagree across plugins:
-  - Confirm `set_unit_system(...)` is called once at process boundary, not
-    per-plugin.
-  - Confirm components mix in `HasPerUnit` consistently.
-- Upgrade chain fails mid-step:
-  - Verify your `VersionReader.read_version(...)` implementation reports the
-    expected source version.
-  - Confirm each `UpgradeStep` is idempotent and constrained with
-    `min_version` / `max_version` where needed.
-
-## Serialization and deserialization
-
-The translated `System` is an infrasys `System`. Persist with infrasys APIs:
+`r2x_core.System` extends infrasys `System` with R2X-specific base power and
+provenance behavior. Use:
 
 ```python
-system.to_json("system.json")
+system.to_json("system.json", overwrite=True)
 loaded = System.from_json("system.json")
 ```
 
-For deeper serialization and migration semantics (composed references,
-`__metadata__`, time series storage backends), see the `infrasys` skill's
-`SERIALIZATION_MIGRATION.md`.
+When a model or serialized field changes, assert the loaded system's public
+fields, component counts, associations, units, and time-series metadata as
+applicable. Route foundational serialized schema migrations through infrasys
+upgrade hooks. Use r2x-core `UpgradeStep` for r2x-core files, mappings, and
+intermediate artifacts.
 
-## Output expectations
+## Public API anti-patterns
 
-- Which surface was touched: plugin / rule / store / units / versioning.
-- Specific APIs invoked for inspection or validation.
-- Result-type usage (`Ok` / `Err`) and how errors propagate through
-  `Plugin.run()`.
-- Persistence and round-trip checks performed.
-- Which integrated references inside this skill were used and why.
+- Treating a context return as a `Result`.
+- Passing rules/components as positional extras to rule executors.
+- Replacing `RuleFilter` records with a callable constructor.
+- Using stale `DataFile` names (`reader_config`, `processing`, `file_info`).
+- Treating file format markers as enums or configuration objects.
+- Constructing `VersionReader(strategy=...)`.
+- Adding `versioning_strategy` to `UpgradeStep`.
+- Import fallbacks that mask a source/docs mismatch.
+- Raw file I/O in plugin code when a `DataStore` boundary applies.
+- Handwritten component construction where `create_component` is the contract.
+- Calling `setup_logging()` from a library module or import side effect.
+- Using `INFO` for per-row/per-component diagnostics or `ERROR` for an expected
+  branch.
+
+## Handoff checklist
+
+- Surface and canonical owner identified.
+- Root symbols and exact signatures verified.
+- Public call pattern shown or corrected.
+- Result/error contract described.
+- Public behavior test added or run.
+- Persistence/file/unit boundary checked when relevant.
+- Source/docs mismatch called out explicitly.

--- a/skills/r2x-core/references/UTILITIES.md
+++ b/skills/r2x-core/references/UTILITIES.md
@@ -71,10 +71,11 @@ if result.is_err():
 generator = result.ok()
 ```
 
-Current root export signature is `create_component(component_class, **field_values)`
-with optional `skip_none` and `skip_validation` keyword controls. The important
-pattern is to keep component construction errors at a single typed boundary
-instead of scattering bare constructors through rules.
+Current root export signature is `create_component(component_class, *, skip_none=True,
+skip_validation=False, **field_values)`. It returns
+`Result[T, pydantic.ValidationError]`. The important pattern is to keep
+component construction errors at a single typed boundary instead of scattering
+bare constructors through rules.
 
 ### Getter helpers
 

--- a/skills/r2x-core/tools/check_api_symbols.py
+++ b/skills/r2x-core/tools/check_api_symbols.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check that the documented r2x-core symbols exist in a package source tree."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+REQUIRED: dict[str, tuple[str, ...]] = {
+    "__init__.py": (
+        "Plugin",
+        "PluginConfig",
+        "PluginContext",
+        "Rule",
+        "RuleFilter",
+        "DataFile",
+        "DataStore",
+        "DataReader",
+        "System",
+        "UnitSystem",
+        "UpgradeStep",
+        "VersionStrategy",
+        "apply_rules_to_context",
+        "apply_single_rule",
+        "run_upgrade_step",
+    ),
+    "plugin_base.py": ("Plugin",),
+    "plugin_config.py": ("PluginConfig",),
+    "plugin_context.py": ("PluginContext",),
+    "plugin_expose.py": ("expose_plugin",),
+    "rules.py": ("Rule", "RuleFilter"),
+    "rules_executor.py": ("apply_rules_to_context", "apply_single_rule"),
+    "datafile.py": ("DataFile", "FileInfo", "ReaderConfig"),
+    "store.py": ("DataStore",),
+    "reader.py": ("DataReader",),
+    "units/__init__.py": ("HasUnits", "HasPerUnit", "UnitSystem"),
+    "versioning.py": ("VersionStrategy", "VersionReader"),
+}
+
+
+def has_symbol(source: str, symbol: str) -> bool:
+    """Return whether source defines or explicitly exports a named symbol."""
+    escaped = re.escape(symbol)
+    definition = re.compile(rf"^\s*(?:class|def)\s+{escaped}\b", re.MULTILINE)
+    import_export = re.compile(rf"^\s*from\s+\S+\s+import[^\n]*\b{escaped}\b", re.MULTILINE)
+    assignment = re.compile(rf"^\s*{escaped}\s*=", re.MULTILINE)
+    all_export = re.compile(rf"[\"']{escaped}[\"']", re.MULTILINE)
+    return bool(
+        definition.search(source)
+        or import_export.search(source)
+        or assignment.search(source)
+        or ("__all__" in source and all_export.search(source))
+    )
+
+
+def check_package(package_root: Path) -> list[str]:
+    """Return missing files and symbols under a package root."""
+    missing: list[str] = []
+    for relative_path, symbols in REQUIRED.items():
+        path = package_root / relative_path
+        if not path.is_file():
+            missing.append(f"missing file: {relative_path}")
+            continue
+        source = path.read_text(encoding="utf-8")
+        missing.extend(
+            f"{relative_path}: missing {symbol}" for symbol in symbols if not has_symbol(source, symbol)
+        )
+    return missing
+
+
+def main() -> int:
+    """Parse arguments, check the package, and print a concise result."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path("src/r2x_core"),
+        help="Path to the r2x_core package root (default: src/r2x_core)",
+    )
+    args = parser.parse_args()
+    package_root = args.repo.expanduser().resolve()
+
+    if not package_root.is_dir():
+        print(f"error: package root not found: {package_root}")
+        return 2
+
+    missing = check_package(package_root)
+    if missing:
+        print("API symbol check failed:")
+        for item in missing:
+            print(f"- {item}")
+        return 1
+
+    print(f"API symbol check passed: {package_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/r2x-core/tools/check_data_store.py
+++ b/skills/r2x-core/tools/check_data_store.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Classify files under a candidate r2x-core DataStore directory."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+KNOWN_EXTENSIONS = {
+    ".csv": "TableFormat",
+    ".tsv": "TableFormat",
+    ".h5": "H5Format",
+    ".hdf5": "H5Format",
+    ".parquet": "ParquetFormat",
+    ".json": "JSONFormat",
+    ".xml": "XMLFormat",
+}
+
+
+def walk_files(root: Path, max_depth: int | None) -> list[Path]:
+    """Return files below root, optionally bounded by relative depth."""
+    root = root.resolve()
+    root_depth = len(root.parts)
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if max_depth is not None and len(path.parts) - root_depth > max_depth:
+            continue
+        files.append(path)
+    return files
+
+
+def main() -> int:
+    """Parse arguments and print a file-format inventory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--max-depth", type=int, default=None)
+    parser.add_argument("--list-unknown", action="store_true")
+    args = parser.parse_args()
+
+    root = args.path.expanduser().resolve()
+    if not root.exists():
+        print(f"error: path not found: {root}")
+        return 2
+    if not root.is_dir():
+        print(f"error: not a directory: {root}")
+        return 2
+
+    files = walk_files(root, args.max_depth)
+    counts: Counter[str] = Counter()
+    unknown: list[Path] = []
+    for path in files:
+        format_name = KNOWN_EXTENSIONS.get(path.suffix.lower())
+        if format_name is None:
+            unknown.append(path)
+        else:
+            counts[format_name] += 1
+
+    print(f"DataStore root: {root}")
+    print(f"Total files: {len(files)}")
+    print("By format:")
+    for format_name, count in sorted(counts.items()):
+        print(f"- {format_name}: {count}")
+    print(f"Unknown-format files: {len(unknown)}")
+    if args.list_unknown:
+        for path in unknown:
+            print(f"  - {path.relative_to(root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/r2x-core/tools/inspect_plugins.py
+++ b/skills/r2x-core/tools/inspect_plugins.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Inspect r2x-core entry points in the active Python environment."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from importlib.metadata import entry_points
+
+DEFAULT_GROUP = "r2x_plugin"
+HOOKS = (
+    "on_validate",
+    "on_prepare",
+    "on_upgrade",
+    "on_build",
+    "on_transform",
+    "on_translate",
+    "on_export",
+    "on_cleanup",
+)
+
+
+def implemented_hooks(plugin_cls: type) -> list[str]:
+    """Return lifecycle hooks implemented outside the base class."""
+    base = None
+    try:
+        from r2x_core import Plugin
+
+        base = Plugin
+    except ImportError:
+        pass
+
+    hooks: list[str] = []
+    for hook in HOOKS:
+        method = getattr(plugin_cls, hook, None)
+        if not callable(method):
+            continue
+        if base is None or getattr(base, hook, None) is not method:
+            hooks.append(hook)
+    return hooks
+
+
+def describe_config(plugin_cls: type) -> tuple[str, list[str]]:
+    """Return config type and field descriptions for a plugin class."""
+    get_config_type = getattr(plugin_cls, "get_config_type", None)
+    config_type = get_config_type() if callable(get_config_type) else None
+    if config_type is None:
+        return "<unknown>", []
+
+    fields = getattr(config_type, "model_fields", {})
+    descriptions = [f"{name}: {field.annotation!r}" for name, field in fields.items()]
+    return config_type.__name__, descriptions
+
+
+def main() -> int:
+    """Enumerate and import entry points from the selected group."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--group", default=DEFAULT_GROUP)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    points = sorted(entry_points(group=args.group), key=lambda point: point.name)
+    if not points:
+        print(f"No entry points found for group '{args.group}'.")
+        return 0
+
+    failures = 0
+    print(f"Discovered plugins in group '{args.group}':")
+    for point in points:
+        try:
+            target = point.load()
+        except Exception as exc:  # discovery must report one bad plugin and continue
+            failures += 1
+            print(f"- {point.name} ({point.value}): FAILED: {exc}")
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+            continue
+
+        print(f"- {point.name}: {point.value}")
+        if not isinstance(target, type):
+            print(f"    target: {type(target).__name__}, not a class")
+            continue
+        config_name, fields = describe_config(target)
+        print(f"    config: {config_name}")
+        for field in fields:
+            print(f"      - {field}")
+        hooks = implemented_hooks(target)
+        print(f"    hooks: {', '.join(hooks) if hooks else '<none>'}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Refresh the repository-local `r2x-core` agent skill around the current public API
and remove unreliable usage patterns that have caused inconsistent translator
implementations. Add source-grounded guidance for Loguru logging, the published
`r2x` CLI workflow, skill installation, API discovery, validation helpers, and
focused evaluation coverage.

## Acceptance criteria

- [x] Make the public r2x-core API the first reference point for plugin, rule, datastore, unit, and upgrade work.
- [x] Document the current `Plugin`, `PluginContext`, `Rule`, `DataFile`, `DataStore`, `UpgradeStep`, and result contracts.
- [x] Add repository-local API, plugin discovery, and datastore validation helpers.
- [x] Add a Loguru policy covering levels, namespaces, sinks, structured context, and application opt-in.
- [x] Document the published `r2x` CLI installation, discovery, direct execution, pipeline validation, logging, and failure triage.
- [x] Move skill installation and update instructions to the repository README, including `npx skills` and `gh skill` workflows.
- [x] Add trigger and output-quality evaluations for public API, logging, and r2x CLI usage.

## Deviations from the original plan

None.

## Testing Strategy

- `just verify`
- `uv run pytest --no-cov -q tests/test_logger.py`
- `uv run python skills/r2x-core/tools/check_api_symbols.py --repo src/r2x_core`
- `uv run ruff check skills/r2x-core/tools`
- `uv run ruff format --check skills/r2x-core/tools`
- `python -m json.tool skills/r2x-core/evals/evals.json`
- `git diff --check`
- Markdown link validation across `README.md` and `skills/r2x-core/`

## References

- Files: `README.md`
- Files: `skills/r2x-core/SKILL.md`
- Files: `skills/r2x-core/references/QUICKREF.md`
- Files: `skills/r2x-core/references/REFERENCE.md`
- Files: `skills/r2x-core/references/LOGGING.md`
- Files: `skills/r2x-core/references/R2X_CLI.md`
- Files: `skills/r2x-core/tools/`
- External CLI: https://github.com/NatLabRockies/r2x-cli
